### PR TITLE
Add `cancelWCA` and refactor WCA Contract

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,10 +13,10 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, develop ]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ master ]
+    branches: [ master, develop ]
   schedule:
     - cron: '29 20 * * 6'
 

--- a/src/main/java/info/skyblond/nekohit/neo/DeployContract.java
+++ b/src/main/java/info/skyblond/nekohit/neo/DeployContract.java
@@ -37,14 +37,8 @@ public class DeployContract {
     private static final Class<?> CONTRACT_CLASS = CatToken.class;
 
     public static void main(String[] args) throws Throwable {
+        Wallet deployWallet = Utils.readWalletWIF();
         Scanner scanner = new Scanner(System.in);
-        System.out.println("Paste deploy account WIF:");
-        String walletWIF = scanner.nextLine();
-        // flush WIF out of screen
-        for (int i = 0; i < 1000; i++) {
-            System.out.println();
-        }
-        Wallet deployWallet = Wallet.withAccounts(Account.fromWIF(walletWIF));
 
         System.out.println("Expected contract owner address: ");
         Utils.require(deployWallet.getDefaultAccount().getAddress().equals(scanner.nextLine()),

--- a/src/main/java/info/skyblond/nekohit/neo/DistributeToken.java
+++ b/src/main/java/info/skyblond/nekohit/neo/DistributeToken.java
@@ -1,0 +1,100 @@
+package info.skyblond.nekohit.neo;
+
+import info.skyblond.nekohit.neo.helper.Utils;
+import io.neow3j.contract.FungibleToken;
+import io.neow3j.protocol.Neow3j;
+import io.neow3j.protocol.core.response.NeoApplicationLog;
+import io.neow3j.protocol.core.response.NeoSendRawTransaction;
+import io.neow3j.protocol.http.HttpService;
+import io.neow3j.script.ScriptBuilder;
+import io.neow3j.transaction.Transaction;
+import io.neow3j.transaction.TransactionBuilder;
+import io.neow3j.types.ContractParameter;
+import io.neow3j.types.Hash160;
+import io.neow3j.utils.Await;
+import io.neow3j.wallet.Account;
+import io.neow3j.wallet.Wallet;
+
+import java.io.IOException;
+import java.math.BigInteger;
+import java.util.Scanner;
+
+import static io.neow3j.transaction.AccountSigner.calledByEntry;
+import static java.util.Arrays.asList;
+
+public class DistributeToken {
+    private static final Neow3j NEOW3J = Neow3j.build(
+            new HttpService("https://testnet1.neo.coz.io:443"));
+
+    private static final FungibleToken CAT_TOKEN = new FungibleToken(
+            new Hash160("0xf461dff74f454e5016421341f115a2e789eadbd7"), NEOW3J);
+
+    private static final BigInteger SATURATE_AMOUNT = BigInteger.valueOf(200_00L);
+
+    private static final ScriptBuilder scriptBuilder = new ScriptBuilder();
+
+    public static void main(String[] args) throws Throwable {
+        Wallet wallet = Utils.readWalletWIF();
+        System.out.println("Account address: " + wallet.getDefaultAccount().getAddress());
+        System.out.println("Account balance: " + queryBalance(wallet.getDefaultAccount().getScriptHash()));
+        Scanner scanner = new Scanner(System.in);
+        System.out.println("Paste address: ");
+        BigInteger acc = BigInteger.ZERO;
+        while (scanner.hasNextLine()) {
+            String line = scanner.nextLine();
+            if (line.isEmpty()) break;
+            Hash160 target = Hash160.fromAddress(line);
+
+            acc = acc.add(transferToken(wallet.getDefaultAccount(), target));
+        }
+
+        System.out.println("Total: " + acc);
+
+        Transaction tx = new TransactionBuilder(NEOW3J)
+                .script(scriptBuilder.toArray())
+                .wallet(wallet)
+                .signers(calledByEntry(wallet.getDefaultAccount().getScriptHash()))
+                .sign();
+
+        NeoSendRawTransaction resp = tx.send();
+        System.out.println("TxId: " + resp.getSendRawTransaction().getHash());
+        Await.waitUntilTransactionIsExecuted(resp.getSendRawTransaction().getHash(), NEOW3J);
+        for (NeoApplicationLog.Execution execution : tx.getApplicationLog().getExecutions()) {
+            System.out.println(execution.getState());
+            System.out.println(execution.getGasConsumed());
+        }
+
+        scanner.close();
+    }
+
+    private static BigInteger queryBalance(Hash160 target) throws IOException {
+        return CAT_TOKEN.getBalanceOf(target);
+    }
+
+    private static BigInteger transferToken(Account account, Hash160 to) throws Throwable {
+        System.out.println("----------------------------------------");
+        System.out.println("Transfer to: " + to);
+        BigInteger target = queryBalance(to);
+        System.out.println("Target balance: " + target);
+        if (target.compareTo(SATURATE_AMOUNT) >= 0) {
+            System.out.println("Address saturated, skip.");
+            return target;
+        }
+
+        target = SATURATE_AMOUNT.subtract(target);
+        System.out.println("Amount: " + target);
+
+        scriptBuilder
+                .contractCall(
+                        CAT_TOKEN.getScriptHash(),
+                        "transfer",
+                        asList(
+                                ContractParameter.hash160(account.getScriptHash()),
+                                ContractParameter.hash160(Hash160.fromAddress("NYukb9Nj59pQZ7SzubZeJUodrhczkXKD1Y")),
+                                ContractParameter.integer(target),
+                                null
+                        )
+                );
+        return target;
+    }
+}

--- a/src/main/java/info/skyblond/nekohit/neo/PublicNetInvoke.java
+++ b/src/main/java/info/skyblond/nekohit/neo/PublicNetInvoke.java
@@ -1,5 +1,6 @@
 package info.skyblond.nekohit.neo;
 
+import info.skyblond.nekohit.neo.helper.Utils;
 import io.neow3j.contract.FungibleToken;
 import io.neow3j.contract.GasToken;
 import io.neow3j.contract.SmartContract;
@@ -20,6 +21,7 @@ import io.neow3j.wallet.Wallet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.File;
 import java.math.BigInteger;
 import java.util.Arrays;
 import java.util.Scanner;
@@ -36,15 +38,7 @@ public final class PublicNetInvoke {
     private static Wallet wallet;
 
     public static void main(String[] args) throws Throwable {
-        Scanner scanner = new Scanner(System.in);
-        System.out.println("Paste account WIF:");
-        String walletWIF = scanner.nextLine();
-        // flush WIF out of screen
-        for (int i = 0; i < 1000; i++) {
-            System.out.println();
-        }
-        scanner.close();
-        wallet = Wallet.withAccounts(Account.fromWIF(walletWIF));
+        wallet = Utils.readWalletWIF();
 
         String id = createAndPayWCA(
                 "中文测试！！！",

--- a/src/main/java/info/skyblond/nekohit/neo/UpdateContract.java
+++ b/src/main/java/info/skyblond/nekohit/neo/UpdateContract.java
@@ -15,7 +15,6 @@ import io.neow3j.transaction.Transaction;
 import io.neow3j.types.ContractParameter;
 import io.neow3j.types.Hash160;
 import io.neow3j.utils.Await;
-import io.neow3j.wallet.Account;
 import io.neow3j.wallet.Wallet;
 
 import java.util.HashMap;
@@ -36,14 +35,8 @@ public class UpdateContract {
     private static final SmartContract CONTRACT = new SmartContract(CONTRACT_HASH, NEOW3J);
 
     public static void main(String[] args) throws Throwable {
+        Wallet deployWallet = Utils.readWalletWIF();
         Scanner scanner = new Scanner(System.in);
-        System.out.println("Paste contract owner account WIF:");
-        String walletWIF = scanner.nextLine();
-        // flush WIF out of screen
-        for (int i = 0; i < 1000; i++) {
-            System.out.println();
-        }
-        Wallet deployWallet = Wallet.withAccounts(Account.fromWIF(walletWIF));
 
         // here we don't check the address, since only owner can update.
         Map<String, String> replaceMap = new HashMap<>();

--- a/src/main/java/info/skyblond/nekohit/neo/contract/WCAAuxiliary.java
+++ b/src/main/java/info/skyblond/nekohit/neo/contract/WCAAuxiliary.java
@@ -12,12 +12,6 @@ import static info.skyblond.nekohit.neo.helper.Utils.require;
  */
 public class WCAAuxiliary {
 
-    static void throwIfNotAvailableToBuy(WCABasicInfo basicInfo, List<WCAMilestone> milestones) throws Exception {
-        require(basicInfo.paid, "You can't buy an unpaid WCA.");
-        require(basicInfo.nextMilestoneIndex == 0, "You can't buy a WCA already started.");
-        require(!milestones.get(0).isExpired(), "You can't buy a WCA already started.");
-    }
-
     static void updateMilestone(
             WCABasicInfo basicInfo, List<WCAMilestone> milestones, int index, String proofOfWork
     ) throws Exception {
@@ -34,15 +28,17 @@ public class WCAAuxiliary {
         basicInfo.nextMilestoneIndex = index + 1;
         basicInfo.finishedCount++;
         basicInfo.lastUpdateTime = currentTime;
+        // update status if we pass the threshold
+        basicInfo.updateStatus(milestones);
     }
 
-    static boolean checkIfReadyToFinish(List<WCAMilestone> milestones) {
+    public static boolean checkIfReadyToFinish(List<WCAMilestone> milestones) {
         WCAMilestone ms = milestones.get(milestones.size() - 1);
         return ms.isFinished() || ms.isExpired();
     }
 
-    static boolean checkIfThresholdMet(WCABasicInfo basicInfo, List<WCAMilestone> milestones) {
-        // pass the threshold, or threshold ms is expired
-        return basicInfo.nextMilestoneIndex > basicInfo.thresholdIndex || milestones.get(basicInfo.thresholdIndex).isExpired();
+    static boolean checkIfThresholdMet(WCABasicInfo basicInfo, List<WCAMilestone> milestones) throws Exception {
+        basicInfo.updateStatus(milestones);
+        return basicInfo.status == 2;
     }
 }

--- a/src/main/java/info/skyblond/nekohit/neo/contract/WCAAuxiliary.java
+++ b/src/main/java/info/skyblond/nekohit/neo/contract/WCAAuxiliary.java
@@ -1,6 +1,6 @@
 package info.skyblond.nekohit.neo.contract;
 
-import info.skyblond.nekohit.neo.domain.Messages;
+import info.skyblond.nekohit.neo.domain.ExceptionMessages;
 import info.skyblond.nekohit.neo.domain.WCABasicInfo;
 import info.skyblond.nekohit.neo.domain.WCAMilestone;
 import io.neow3j.devpack.List;
@@ -18,19 +18,19 @@ public class WCAAuxiliary {
     ) throws Exception {
         // check cool-down time first
         int currentTime = Runtime.getTime();
-        require(basicInfo.lastUpdateTime + basicInfo.coolDownInterval <= currentTime, Messages.COOL_DOWN_TIME_NOT_MET);
-        require(index >= basicInfo.nextMilestoneIndex, Messages.INVALID_MILESTONE_PASSED);
+        require(basicInfo.lastUpdateTime + basicInfo.coolDownInterval <= currentTime, ExceptionMessages.COOL_DOWN_TIME_NOT_MET);
+        require(index >= basicInfo.nextMilestoneIndex, ExceptionMessages.INVALID_MILESTONE_PASSED);
         WCAMilestone ms = milestones.get(index);
-        require(!ms.isFinished(), Messages.INVALID_MILESTONE_FINISHED);
-        require(!ms.isExpired(), Messages.INVALID_MILESTONE_EXPIRED);
+        require(!ms.isFinished(), ExceptionMessages.INVALID_MILESTONE_FINISHED);
+        require(!ms.isExpired(), ExceptionMessages.INVALID_MILESTONE_EXPIRED);
         // not finished nor expired, then we can modify it.
-        require(proofOfWork != null && proofOfWork.length() != 0, Messages.INVALID_PROOF_OF_WORK);
+        require(proofOfWork != null && proofOfWork.length() != 0, ExceptionMessages.INVALID_PROOF_OF_WORK);
         ms.linkToResult = proofOfWork;
         basicInfo.nextMilestoneIndex = index + 1;
         basicInfo.finishedCount++;
         basicInfo.lastUpdateTime = currentTime;
         // update status if we pass the threshold
-        basicInfo.updateStatus(milestones);
+        updateStatus(basicInfo, milestones);
     }
 
     public static boolean checkIfReadyToFinish(List<WCAMilestone> milestones) {
@@ -39,7 +39,24 @@ public class WCAAuxiliary {
     }
 
     static boolean checkIfThresholdMet(WCABasicInfo basicInfo, List<WCAMilestone> milestones) {
-        basicInfo.updateStatus(milestones);
+        updateStatus(basicInfo, milestones);
         return basicInfo.status == 2;
+    }
+
+    /**
+     * Update the status based on milestones.
+     * Mainly: OPEN -> ACTIVE, if the threshold milestone is passed
+     */
+    public static void updateStatus(WCABasicInfo basicInfo, List<WCAMilestone> milestones) {
+        if (basicInfo.status == 1) {
+            // is open status
+            WCAMilestone threshold = milestones.get(basicInfo.thresholdIndex);
+            if (basicInfo.nextMilestoneIndex > basicInfo.thresholdIndex ||
+                    threshold.isExpired() || threshold.isFinished()) {
+                // threshold passed, finished, or expired
+                // then set the WCA to ACTIVE
+                basicInfo.status = 2;
+            }
+        }
     }
 }

--- a/src/main/java/info/skyblond/nekohit/neo/contract/WCAAuxiliary.java
+++ b/src/main/java/info/skyblond/nekohit/neo/contract/WCAAuxiliary.java
@@ -1,5 +1,6 @@
 package info.skyblond.nekohit.neo.contract;
 
+import info.skyblond.nekohit.neo.domain.Messages;
 import info.skyblond.nekohit.neo.domain.WCABasicInfo;
 import info.skyblond.nekohit.neo.domain.WCAMilestone;
 import io.neow3j.devpack.List;
@@ -8,7 +9,7 @@ import io.neow3j.devpack.Runtime;
 import static info.skyblond.nekohit.neo.helper.Utils.require;
 
 /**
- * This class contains some helper function specific to WCAContract.class
+ * This class contains some helper function specific to WCAContract
  */
 public class WCAAuxiliary {
 
@@ -17,13 +18,13 @@ public class WCAAuxiliary {
     ) throws Exception {
         // check cool-down time first
         int currentTime = Runtime.getTime();
-        require(basicInfo.lastUpdateTime + basicInfo.coolDownInterval <= currentTime, "Cool down time not met");
-        require(index >= basicInfo.nextMilestoneIndex, "You can't finish a passed milestone");
+        require(basicInfo.lastUpdateTime + basicInfo.coolDownInterval <= currentTime, Messages.COOL_DOWN_TIME_NOT_MET);
+        require(index >= basicInfo.nextMilestoneIndex, Messages.INVALID_MILESTONE_PASSED);
         WCAMilestone ms = milestones.get(index);
-        require(!ms.isFinished(), "You can't finish a finished milestone");
-        require(!ms.isExpired(), "You can't finish a expired milestone");
+        require(!ms.isFinished(), Messages.INVALID_MILESTONE_FINISHED);
+        require(!ms.isExpired(), Messages.INVALID_MILESTONE_EXPIRED);
         // not finished nor expired, then we can modify it.
-        require(proofOfWork != null && proofOfWork.length() != 0, "Proof of work must be valid.");
+        require(proofOfWork != null && proofOfWork.length() != 0, Messages.INVALID_PROOF_OF_WORK);
         ms.linkToResult = proofOfWork;
         basicInfo.nextMilestoneIndex = index + 1;
         basicInfo.finishedCount++;
@@ -37,7 +38,7 @@ public class WCAAuxiliary {
         return ms.isFinished() || ms.isExpired();
     }
 
-    static boolean checkIfThresholdMet(WCABasicInfo basicInfo, List<WCAMilestone> milestones) throws Exception {
+    static boolean checkIfThresholdMet(WCABasicInfo basicInfo, List<WCAMilestone> milestones) {
         basicInfo.updateStatus(milestones);
         return basicInfo.status == 2;
     }

--- a/src/main/java/info/skyblond/nekohit/neo/contract/WCAContract.java
+++ b/src/main/java/info/skyblond/nekohit/neo/contract/WCAContract.java
@@ -1,9 +1,6 @@
 package info.skyblond.nekohit.neo.contract;
 
-import info.skyblond.nekohit.neo.domain.WCABasicInfo;
-import info.skyblond.nekohit.neo.domain.WCABuyerInfo;
-import info.skyblond.nekohit.neo.domain.WCAMilestone;
-import info.skyblond.nekohit.neo.domain.WCAPojo;
+import info.skyblond.nekohit.neo.domain.*;
 import info.skyblond.nekohit.neo.helper.Pair;
 import io.neow3j.devpack.Runtime;
 import io.neow3j.devpack.*;
@@ -68,30 +65,34 @@ public class WCAContract {
 
     @OnNEP17Payment
     public static void onPayment(Hash160 from, int amount, Object data) throws Exception {
-        require(CAT_TOKEN_HASH == Runtime.getCallingScriptHash(), "Only Cat Token can invoke this function.");
-        require(amount > 0, "Transfer amount must be a positive number.");
+        require(CAT_TOKEN_HASH == Runtime.getCallingScriptHash(), Messages.INVALID_CALLER);
+        require(amount > 0, Messages.INVALID_AMOUNT);
         String identifier = (String) data;
         WCABasicInfo basicInfo = getWCABasicInfo(identifier);
-        require(basicInfo != null, "Identifier not found.");
+        require(basicInfo != null, Messages.ID_NOT_FOUND);
         List<WCAMilestone> milestones = getWCAMilestones(identifier);
-        require(milestones != null, "Identifier not found.");
+        require(milestones != null, Messages.ID_NOT_FOUND);
 
         if (basicInfo.owner.equals(from)) {
             // owner paying stake
-            require(!basicInfo.paid, "You can't pay a paid WCA.");
-            require(!checkIfReadyToFinish(milestones), "You can't pay a expired WCA.");
-            require(basicInfo.getTotalStake() == amount, "Amount not correct");
-            // unpaid before, not finished(expired), amount is correct
-            basicInfo.paid = true;
-            wcaBasicInfoMap.put(identifier, StdLib.serialize(basicInfo));
+            require(basicInfo.status == 0, Messages.INVALID_STATUS_ALLOW_PENDING);
+            require(basicInfo.getTotalStake() == amount, Messages.INCORRECT_AMOUNT);
+            // unpaid before, amount is correct, set to OPEN
+            basicInfo.status = 1;
+            // update status in case the threshold milestone is expired
+            basicInfo.updateStatus(milestones);
+            updateWCABasicInfo(identifier, basicInfo);
             onPayWCA.fire(from, identifier, amount);
         } else {
-            // buyer want to buy a WCA
-            throwIfNotAvailableToBuy(basicInfo, milestones);
+            // buyer want to buy a WCA, update status first
+            basicInfo.updateStatus(milestones);
+            require(basicInfo.status == 1 || basicInfo.status == 2, Messages.INVALID_STATUS_ALLOW_OPEN_AND_ACTIVE);
+            require(!checkIfReadyToFinish(milestones), Messages.INVALID_STATUS_READY_TO_FINISH);
             WCABuyerInfo buyerInfo = getWCABuyerInfo(identifier);
-            require(buyerInfo != null, "Buyer info not found.");
+            require(buyerInfo != null, Messages.ID_NOT_FOUND);
             buyerInfo.recordPurchase(from, amount);
-            wcaBuyerInfoMap.put(identifier, StdLib.serialize(buyerInfo));
+            updateWCABasicInfo(identifier, basicInfo);
+            updateWCABuyerInfo(identifier, buyerInfo);
             onBuyWCA.fire(from, identifier, amount);
         }
     }
@@ -130,8 +131,8 @@ public class WCAContract {
     public static String advanceQuery(
             Hash160 creator, Hash160 buyer, int page, int size
     ) throws Exception {
-        require(page >= 1, "Page must bigger than 0");
-        require(size >= 1, "Size must bigger than 0");
+        require(page >= 1, Messages.INVALID_PAGE);
+        require(size >= 1, Messages.INVALID_SIZE);
         int offset = (page - 1) * size;
         int count = 0;
         List<WCAPojo> result = new List<>();
@@ -142,8 +143,9 @@ public class WCAContract {
             List<WCAMilestone> milestonesInfo = getWCAMilestones(identifier);
             WCABuyerInfo buyerInfo = getWCABuyerInfo(identifier);
 
-            if (basicInfo == null || milestonesInfo == null || buyerInfo == null)
+            if (basicInfo == null || milestonesInfo == null || buyerInfo == null) {
                 continue;
+            }
 
             if (!basicInfo.bePublic) {
                 continue;
@@ -177,38 +179,32 @@ public class WCAContract {
             int thresholdIndex, int coolDownInterval,
             boolean bePublic, String identifier
     ) throws Exception {
-        require(Runtime.checkWitness(owner) || owner == Runtime.getCallingScriptHash(), "Invalid sender signature. The owner of the wca needs to be the signing account.");
+        require(Runtime.checkWitness(owner) || owner == Runtime.getCallingScriptHash(), Messages.INVALID_SIGNATURE);
         // identifier should be unique
-        require(wcaBasicInfoMap.get(identifier) == null, "Duplicate identifier.");
+        require(wcaBasicInfoMap.get(identifier) == null, Messages.DUPLICATED_ID);
         // check milestone
-        require(milestoneTitles.length == milestoneDescriptions.length, "Cannot decide milestones count.");
-        require(milestoneDescriptions.length == endTimestamps.length, "Cannot decide milestones count.");
+        require(milestoneTitles.length == milestoneDescriptions.length, Messages.INVALID_MILESTONES_COUNT);
+        require(milestoneDescriptions.length == endTimestamps.length, Messages.INVALID_MILESTONES_COUNT);
 
         // convert to object on the fly
         List<WCAMilestone> milestones = new List<>();
         int lastTimestamp = 0;
         for (int i = 0; i < endTimestamps.length; i++) {
-            require(lastTimestamp < endTimestamps[i], "The end timestamp should increase.");
-            require(endTimestamps[i] > Runtime.getTime(), "The end timestamp is already expired.");
+            require(lastTimestamp < endTimestamps[i], Messages.INVALID_TIMESTAMP);
+            require(endTimestamps[i] > Runtime.getTime(), Messages.EXPIRED_TIMESTAMP);
             lastTimestamp = endTimestamps[i];
             milestones.add(new WCAMilestone(milestoneTitles[i], milestoneDescriptions[i], endTimestamps[i]));
         }
 
         // create wca info obj
-        WCABasicInfo info = new WCABasicInfo(
+        WCABasicInfo basicInfo = new WCABasicInfo(
                 owner, wcaDescription, stakePer100Token, maxTokenSoldCount,
                 milestones.size(), thresholdIndex, coolDownInterval, bePublic
         );
-
-        ByteString basicData = StdLib.serialize(info);
-        ByteString milestoneData = StdLib.serialize(milestones);
-        ByteString buyerData = StdLib.serialize(new WCABuyerInfo(maxTokenSoldCount));
-
         // store
-        wcaBasicInfoMap.put(identifier, basicData);
-        wcaMilestonesMap.put(identifier, milestoneData);
-        wcaBuyerInfoMap.put(identifier, buyerData);
-
+        updateWCABasicInfo(identifier, basicInfo);
+        updateWCABuyerInfo(identifier, new WCABuyerInfo(maxTokenSoldCount));
+        updateWCAMilestones(identifier, milestones);
         // fire event and done
         onCreateWCA.fire(owner, identifier, milestones.size());
         return identifier;
@@ -216,20 +212,18 @@ public class WCAContract {
 
     public static void finishMilestone(String identifier, int index, String proofOfWork) throws Exception {
         WCABasicInfo basicInfo = getWCABasicInfo(identifier);
-        require(basicInfo != null, "Identifier not found.");
+        require(basicInfo != null, Messages.ID_NOT_FOUND);
         // only creator can update WCA to finished
-        require(Runtime.checkWitness(basicInfo.owner) || basicInfo.owner == Runtime.getCallingScriptHash(),
-                "Invalid caller signature. The caller needs to be the owner account.");
-        require(basicInfo.paid, "You can't finish an unpaid WCA.");
-        require(!basicInfo.finished, "You can't finish an finished WCA.");
+        require(Runtime.checkWitness(basicInfo.owner) || basicInfo.owner == Runtime.getCallingScriptHash(), Messages.INVALID_SIGNATURE);
+        require(basicInfo.status == 1 || basicInfo.status == 2, Messages.INVALID_STATUS_ALLOW_OPEN_AND_ACTIVE);
         List<WCAMilestone> milestones = getWCAMilestones(identifier);
-        require(milestones != null, "Identifier not found.");
+        require(milestones != null, Messages.ID_NOT_FOUND);
 
         updateMilestone(basicInfo, milestones, index, proofOfWork);
-        // store it back
-        wcaBasicInfoMap.put(identifier, StdLib.serialize(basicInfo));
-        wcaMilestonesMap.put(identifier, StdLib.serialize(milestones));
 
+        // store it back
+        updateWCABasicInfo(identifier, basicInfo);
+        updateWCAMilestones(identifier, milestones);
         onFinishMilestone.fire(identifier, index, proofOfWork);
 
         // if whole WCA is finished
@@ -240,19 +234,18 @@ public class WCAContract {
 
     public static void finishWCA(String identifier) throws Exception {
         WCABasicInfo basicInfo = getWCABasicInfo(identifier);
-        require(basicInfo != null, "Identifier not found.");
-        require(basicInfo.paid, "You can not finish an unpaid WCA.");
-        require(!basicInfo.finished, "You can not finish a WCA twice.");
+        require(basicInfo != null, Messages.ID_NOT_FOUND);
+        require(basicInfo.status == 1 || basicInfo.status == 2, Messages.INVALID_STATUS_ALLOW_OPEN_AND_ACTIVE);
         List<WCAMilestone> milestones = getWCAMilestones(identifier);
-        require(milestones != null, "Identifier not found.");
+        require(milestones != null, Messages.ID_NOT_FOUND);
 
         if (!Runtime.checkWitness(basicInfo.owner)) {
             // only owner can finish an unfinished WCA
-            require(checkIfReadyToFinish(milestones), "You can only apply this to a ready-to-finish WCA.");
+            require(checkIfReadyToFinish(milestones), Messages.INVALID_STATUS_ALLOW_READY_TO_FINISH);
         }
         // get wca buyer info obj
         WCABuyerInfo buyerInfo = getWCABuyerInfo(identifier);
-        require(buyerInfo != null, "Buyer info not found.");
+        require(buyerInfo != null, Messages.ID_NOT_FOUND);
 
         int remainTokens = basicInfo.getTotalStake() + buyerInfo.totalPurchasedAmount;
         int totalMilestones = basicInfo.milestoneCount;
@@ -273,27 +266,25 @@ public class WCAContract {
         if (remainTokens > 0) {
             transferTokenTo(basicInfo.owner, remainTokens, identifier);
         }
-        basicInfo.finished = true;
+        basicInfo.status = 3;
         basicInfo.lastUpdateTime = Runtime.getTime();
         // store it back
-        wcaBasicInfoMap.put(identifier, StdLib.serialize(basicInfo));
-
+        updateWCABasicInfo(identifier, basicInfo);
         onFinishWCA.fire(identifier);
     }
 
     public static void refund(String identifier, Hash160 buyer) throws Exception {
-        require(Hash160.isValid(buyer), "Buyer address is not a valid address.");
-        require(Runtime.checkWitness(buyer) || buyer == Runtime.getCallingScriptHash(),
-                "Invalid sender signature. The buyer needs to be the signing account.");
+        require(Hash160.isValid(buyer), Messages.INVALID_HASH160);
+        require(Runtime.checkWitness(buyer) || buyer == Runtime.getCallingScriptHash(), Messages.INVALID_SIGNATURE);
         WCABasicInfo basicInfo = getWCABasicInfo(identifier);
-        require(basicInfo != null, "Identifier not found.");
-        require(basicInfo.paid, "You can not refund an unpaid WCA.");
-        require(!basicInfo.finished, "You can not refund a finished WCA.");
+        require(basicInfo != null, Messages.ID_NOT_FOUND);
+        require(basicInfo.status == 1 || basicInfo.status == 2,
+                Messages.INVALID_STATUS_ALLOW_OPEN_AND_ACTIVE);
         List<WCAMilestone> milestones = getWCAMilestones(identifier);
-        require(milestones != null, "Identifier not found.");
-        require(!checkIfReadyToFinish(milestones), "You can not refund a finished WCA.");
+        require(milestones != null, Messages.ID_NOT_FOUND);
+        require(!checkIfReadyToFinish(milestones), Messages.INVALID_STATUS_READY_TO_FINISH);
         WCABuyerInfo buyerInfo = getWCABuyerInfo(identifier);
-        require(buyerInfo != null, "Identifier not found.");
+        require(buyerInfo != null, Messages.ID_NOT_FOUND);
 
         if (checkIfThresholdMet(basicInfo, milestones)) {
             // after the threshold
@@ -309,8 +300,7 @@ public class WCAContract {
         }
 
         // update buyer info
-        ByteString buyerData = StdLib.serialize(buyerInfo);
-        wcaBuyerInfoMap.put(identifier, buyerData);
+        updateWCABuyerInfo(identifier, buyerInfo);
     }
 
     public static void update(ByteString script, String manifest) throws Exception {
@@ -332,7 +322,7 @@ public class WCAContract {
     }
 
     // ---------- Auxiliary functions ----------
-    // Currently due to neow3j/neow3j#601, they won't work if they are outside of this contract.
+    // Currently due to neow3j/neow3j#601, they won't work if they are outside this contract.
     private static void transferTokenTo(Hash160 target, int amount, String identifier) {
         Contract.call(CAT_TOKEN_HASH, "transfer", CallFlags.All,
                 new Object[]{Runtime.getExecutingScriptHash(), target, amount, identifier});
@@ -360,5 +350,17 @@ public class WCAContract {
             return null;
         }
         return (List<WCAMilestone>) StdLib.deserialize(data);
+    }
+
+    private static void updateWCABasicInfo(String identifier, WCABasicInfo data) {
+        wcaBasicInfoMap.put(identifier, StdLib.serialize(data));
+    }
+
+    private static void updateWCABuyerInfo(String identifier, WCABuyerInfo data) {
+        wcaBuyerInfoMap.put(identifier, StdLib.serialize(data));
+    }
+
+    private static void updateWCAMilestones(String identifier, List<WCAMilestone> data) {
+        wcaMilestonesMap.put(identifier, StdLib.serialize(data));
     }
 }

--- a/src/main/java/info/skyblond/nekohit/neo/domain/ExceptionMessages.java
+++ b/src/main/java/info/skyblond/nekohit/neo/domain/ExceptionMessages.java
@@ -1,6 +1,6 @@
 package info.skyblond.nekohit.neo.domain;
 
-public class Messages {
+public class ExceptionMessages {
     public static final String INVALID_CALLER =
             "Invalid caller. Only CatToken are allowed.";
 

--- a/src/main/java/info/skyblond/nekohit/neo/domain/Messages.java
+++ b/src/main/java/info/skyblond/nekohit/neo/domain/Messages.java
@@ -16,6 +16,9 @@ public class Messages {
     public static final String INVALID_STATUS_ALLOW_OPEN_AND_ACTIVE =
             "Invalid status. Only OPEN and ACTIVE is allowed.";
 
+    public static final String INVALID_STATUS_ALLOW_PENDING_AND_OPEN =
+            "Invalid status. Only PENDING and OPEN is allowed.";
+
     public static final String INVALID_STATUS_ALLOW_READY_TO_FINISH =
             "Invalid status. Only Ready-To-Finished is allowed.";
 

--- a/src/main/java/info/skyblond/nekohit/neo/domain/Messages.java
+++ b/src/main/java/info/skyblond/nekohit/neo/domain/Messages.java
@@ -1,0 +1,54 @@
+package info.skyblond.nekohit.neo.domain;
+
+public class Messages {
+    public static final String INVALID_CALLER =
+            "Invalid caller. Only CatToken are allowed.";
+
+    public static final String INVALID_AMOUNT =
+            "Invalid amount. Only positive numbers are allowed.";
+
+    public static final String ID_NOT_FOUND =
+            "Identifier not found.";
+
+    public static final String INVALID_STATUS_ALLOW_PENDING =
+            "Invalid status. Only PENDING is allowed.";
+
+    public static final String INVALID_STATUS_ALLOW_OPEN_AND_ACTIVE =
+            "Invalid status. Only OPEN and ACTIVE is allowed.";
+
+    public static final String INVALID_STATUS_ALLOW_READY_TO_FINISH =
+            "Invalid status. Only Ready-To-Finished is allowed.";
+
+    public static final String INVALID_STATUS_READY_TO_FINISH =
+            "Invalid status: Ready-To-Finish.";
+
+    public static final String INVALID_HASH160 =
+            "Invalid hash160.";
+
+    public static final String INCORRECT_AMOUNT =
+            "Amount not correct.";
+
+    public static final String INVALID_PAGE =
+            "Invalid page. Only positive numbers are allowed.";
+
+    public static final String INVALID_SIZE =
+            "Invalid size. Only positive numbers are allowed.";
+
+    public static final String INVALID_SIGNATURE =
+            "Invalid signature.";
+
+    public static final String DUPLICATED_ID =
+            "Identifier duplicated.";
+
+    public static final String INVALID_MILESTONES_COUNT =
+            "Invalid milestones count.";
+
+    public static final String INVALID_TIMESTAMP =
+            "Invalid timestamp. Only increasing timestamp is allowed.";
+
+    public static final String EXPIRED_TIMESTAMP =
+            "Expired timestamp.";
+
+    public static final String NULL_DESCRIPTION =
+            "Invalid description. Only non-null value is allowed.";
+}

--- a/src/main/java/info/skyblond/nekohit/neo/domain/Messages.java
+++ b/src/main/java/info/skyblond/nekohit/neo/domain/Messages.java
@@ -7,8 +7,11 @@ public class Messages {
     public static final String INVALID_AMOUNT =
             "Invalid amount. Only positive numbers are allowed.";
 
-    public static final String ID_NOT_FOUND =
-            "Identifier not found.";
+    public static final String RECORD_NOT_FOUND =
+            "Record not found.";
+
+    public static final String BROKEN_RECORD =
+            "Record found but seems broken.";
 
     public static final String INVALID_STATUS_ALLOW_PENDING =
             "Invalid status. Only PENDING is allowed.";
@@ -54,4 +57,31 @@ public class Messages {
 
     public static final String NULL_DESCRIPTION =
             "Invalid description. Only non-null value is allowed.";
+
+    public static final String INVALID_MILESTONE_PASSED =
+            "Invalid milestone: Already passed.";
+
+    public static final String INVALID_MILESTONE_FINISHED =
+            "Invalid milestone: Already finished.";
+
+    public static final String INVALID_MILESTONE_EXPIRED =
+            "Invalid milestone: Already expired.";
+
+    public static final String INVALID_PROOF_OF_WORK =
+            "Invalid proof of work. Only non-null and non-blank content allowed.";
+
+    public static final String COOL_DOWN_TIME_NOT_MET =
+            "Cool-down time not met";
+
+    public static final String INVALID_STAKE_RATE =
+            "Invalid stake amount per 100 token. Only positive numbers are allowed.";
+
+    public static final String INVALID_MAX_SELL_AMOUNT =
+            "Invalid max sell token count. Only positive numbers are allowed.";
+
+    public static final String INVALID_THRESHOLD_INDEX =
+            "Invalid thresholdIndex: Index out of range.";
+
+    public static final String INVALID_COOL_DOWN_INTERVAL =
+            "Invalid cool-down interval. Only positive numbers are allowed.";
 }

--- a/src/main/java/info/skyblond/nekohit/neo/domain/WCABasicInfo.java
+++ b/src/main/java/info/skyblond/nekohit/neo/domain/WCABasicInfo.java
@@ -1,6 +1,7 @@
 package info.skyblond.nekohit.neo.domain;
 
 import io.neow3j.devpack.Hash160;
+import io.neow3j.devpack.List;
 import io.neow3j.devpack.Runtime;
 
 import static info.skyblond.nekohit.neo.helper.Utils.require;
@@ -32,29 +33,28 @@ public class WCABasicInfo {
     public int nextMilestoneIndex;
 
     /**
-     * Indicate if the stake is paid
+     * Status of this WCA. Note: OPEN might become ACTIVE overtime. <br>
+     * 0 - PENDING, the initialized status, only payStake and cancel is allowed.<br>
+     * 1 - OPEN, from PENDING, after pay the stake, ready to operate.<br>
+     * 2 - ACTIVE, from OPEN, after pass the threshold milestone.<br>
+     * 3 - FINISHED, from OPEN or ACTIVE, after creator finish this WCA.<br>
      */
-    public boolean paid;
-
-    /**
-     * If this WCA is accounted and finished.
-     */
-    public boolean finished;
+    public int status;
 
     public WCABasicInfo(
             Hash160 owner, String description,
             int stakePer100Token, int maxTokenSoldCount,
             int milestoneCount, int thresholdIndex, int coolDownInterval, boolean bePublic
     ) throws Exception {
-        require(Hash160.isValid(owner), "Owner address is not a valid address.");
+        require(Hash160.isValid(owner), Messages.INVALID_HASH160);
         this.owner = owner;
-        require(description != null, "Description can be empty, but not null.");
+        require(description != null, Messages.NULL_DESCRIPTION);
         this.description = description;
         require(stakePer100Token > 0, "The stake amount per 100 token must be positive.");
         require(maxTokenSoldCount > 0, "The max sell token count must be positive.");
         this.stakePer100Token = stakePer100Token;
         this.maxTokenSoldCount = maxTokenSoldCount;
-        require(milestoneCount > 0, "You must have at least 1 milestone.");
+        require(milestoneCount > 0, Messages.INVALID_MILESTONES_COUNT);
         this.milestoneCount = milestoneCount;
         if (thresholdIndex >= 0 && thresholdIndex < this.milestoneCount) {
             this.thresholdIndex = thresholdIndex;
@@ -65,12 +65,29 @@ public class WCABasicInfo {
         this.coolDownInterval = coolDownInterval;
         this.bePublic = bePublic;
 
-        creationTimestamp = Runtime.getTime();
-        lastUpdateTime = -1;
-        finishedCount = 0;
-        nextMilestoneIndex = 0;
-        paid = false;
-        finished = false;
+        this.creationTimestamp = Runtime.getTime();
+        this.lastUpdateTime = -1;
+        this.finishedCount = 0;
+        this.nextMilestoneIndex = 0;
+        this.status = 0;
+    }
+
+
+    /**
+     * Update the status based on milestones.
+     * Mainly: OPEN -> ACTIVE, if the threshold milestone is passed
+     */
+    public void updateStatus(List<WCAMilestone> milestones) {
+        if (this.status == 1) {
+            // is open status
+            WCAMilestone threshold = milestones.get(this.thresholdIndex);
+            if (this.nextMilestoneIndex > this.thresholdIndex ||
+                    threshold.isExpired() || threshold.isFinished()) {
+                // threshold passed, finished, or expired
+                // then set the WCA to ACTIVE
+                this.status = 2;
+            }
+        }
     }
 
     /**
@@ -79,6 +96,6 @@ public class WCABasicInfo {
      * @return token count in fraction. 1.00 token means 100
      */
     public int getTotalStake() {
-        return stakePer100Token * maxTokenSoldCount / 100;
+        return this.stakePer100Token * this.maxTokenSoldCount / 100;
     }
 }

--- a/src/main/java/info/skyblond/nekohit/neo/domain/WCABasicInfo.java
+++ b/src/main/java/info/skyblond/nekohit/neo/domain/WCABasicInfo.java
@@ -46,22 +46,22 @@ public class WCABasicInfo {
             int stakePer100Token, int maxTokenSoldCount,
             int milestoneCount, int thresholdIndex, int coolDownInterval, boolean bePublic
     ) throws Exception {
-        require(Hash160.isValid(owner), Messages.INVALID_HASH160);
+        require(Hash160.isValid(owner), ExceptionMessages.INVALID_HASH160);
         this.owner = owner;
-        require(description != null, Messages.NULL_DESCRIPTION);
+        require(description != null, ExceptionMessages.NULL_DESCRIPTION);
         this.description = description;
-        require(stakePer100Token > 0, Messages.INVALID_STAKE_RATE);
-        require(maxTokenSoldCount > 0, Messages.INVALID_MAX_SELL_AMOUNT);
+        require(stakePer100Token > 0, ExceptionMessages.INVALID_STAKE_RATE);
+        require(maxTokenSoldCount > 0, ExceptionMessages.INVALID_MAX_SELL_AMOUNT);
         this.stakePer100Token = stakePer100Token;
         this.maxTokenSoldCount = maxTokenSoldCount;
-        require(milestoneCount > 0, Messages.INVALID_MILESTONES_COUNT);
+        require(milestoneCount > 0, ExceptionMessages.INVALID_MILESTONES_COUNT);
         this.milestoneCount = milestoneCount;
         if (thresholdIndex >= 0 && thresholdIndex < this.milestoneCount) {
             this.thresholdIndex = thresholdIndex;
         } else {
-            throw new Exception(Messages.INVALID_THRESHOLD_INDEX);
+            throw new Exception(ExceptionMessages.INVALID_THRESHOLD_INDEX);
         }
-        require(coolDownInterval > 0, Messages.INVALID_COOL_DOWN_INTERVAL);
+        require(coolDownInterval > 0, ExceptionMessages.INVALID_COOL_DOWN_INTERVAL);
         this.coolDownInterval = coolDownInterval;
         this.bePublic = bePublic;
 
@@ -72,23 +72,6 @@ public class WCABasicInfo {
         this.status = 0;
     }
 
-
-    /**
-     * Update the status based on milestones.
-     * Mainly: OPEN -> ACTIVE, if the threshold milestone is passed
-     */
-    public void updateStatus(List<WCAMilestone> milestones) {
-        if (this.status == 1) {
-            // is open status
-            WCAMilestone threshold = milestones.get(this.thresholdIndex);
-            if (this.nextMilestoneIndex > this.thresholdIndex ||
-                    threshold.isExpired() || threshold.isFinished()) {
-                // threshold passed, finished, or expired
-                // then set the WCA to ACTIVE
-                this.status = 2;
-            }
-        }
-    }
 
     /**
      * Get total staked token count

--- a/src/main/java/info/skyblond/nekohit/neo/domain/WCABasicInfo.java
+++ b/src/main/java/info/skyblond/nekohit/neo/domain/WCABasicInfo.java
@@ -50,8 +50,8 @@ public class WCABasicInfo {
         this.owner = owner;
         require(description != null, Messages.NULL_DESCRIPTION);
         this.description = description;
-        require(stakePer100Token > 0, "The stake amount per 100 token must be positive.");
-        require(maxTokenSoldCount > 0, "The max sell token count must be positive.");
+        require(stakePer100Token > 0, Messages.INVALID_STAKE_RATE);
+        require(maxTokenSoldCount > 0, Messages.INVALID_MAX_SELL_AMOUNT);
         this.stakePer100Token = stakePer100Token;
         this.maxTokenSoldCount = maxTokenSoldCount;
         require(milestoneCount > 0, Messages.INVALID_MILESTONES_COUNT);
@@ -59,9 +59,9 @@ public class WCABasicInfo {
         if (thresholdIndex >= 0 && thresholdIndex < this.milestoneCount) {
             this.thresholdIndex = thresholdIndex;
         } else {
-            throw new Exception("Invalid value for thresholdIndex");
+            throw new Exception(Messages.INVALID_THRESHOLD_INDEX);
         }
-        require(coolDownInterval >= 0, "Cool down interval must not be negative.");
+        require(coolDownInterval > 0, Messages.INVALID_COOL_DOWN_INTERVAL);
         this.coolDownInterval = coolDownInterval;
         this.bePublic = bePublic;
 

--- a/src/main/java/info/skyblond/nekohit/neo/domain/WCABuyerInfo.java
+++ b/src/main/java/info/skyblond/nekohit/neo/domain/WCABuyerInfo.java
@@ -21,7 +21,7 @@ public class WCABuyerInfo {
      * Record buyer's purchase record into list.
      *
      * @param buyer  who is making this purchase
-     * @param amount how much does he/her/it want to buy
+     * @param amount how much does he/her/it wants to buy
      * @throws Exception if remain amount is smaller than buyer's intended amount
      */
     public void recordPurchase(Hash160 buyer, int amount) throws Exception {
@@ -46,9 +46,9 @@ public class WCABuyerInfo {
      * @throws Exception if partial refund is not available
      */
     public Pair<Integer, Integer> partialRefund(WCABasicInfo basicInfo, Hash160 buyer) throws Exception {
-        require(this.purchases.containsKey(buyer), "Purchase not found");
+        require(this.purchases.containsKey(buyer), Messages.RECORD_NOT_FOUND);
         Integer buyerPurchaseAmount = this.purchases.get(buyer);
-        require(buyerPurchaseAmount != null, "Purchase found but amount is null");
+        require(buyerPurchaseAmount != null, Messages.BROKEN_RECORD);
 
         int totalMilestones = basicInfo.milestoneCount;
         // finished milestone belongs to creator
@@ -65,9 +65,9 @@ public class WCABuyerInfo {
     }
 
     public int fullRefund(Hash160 buyer) throws Exception {
-        require(this.purchases.containsKey(buyer), "Purchase not found");
+        require(this.purchases.containsKey(buyer), Messages.RECORD_NOT_FOUND);
         Integer amount = this.purchases.get(buyer);
-        require(amount != null, "Purchase found but amount is null");
+        require(amount != null, Messages.BROKEN_RECORD);
         this.purchases.remove(buyer);
         // add to remain token
         this.remainTokenCount += amount;

--- a/src/main/java/info/skyblond/nekohit/neo/domain/WCABuyerInfo.java
+++ b/src/main/java/info/skyblond/nekohit/neo/domain/WCABuyerInfo.java
@@ -46,9 +46,9 @@ public class WCABuyerInfo {
      * @throws Exception if partial refund is not available
      */
     public Pair<Integer, Integer> partialRefund(WCABasicInfo basicInfo, Hash160 buyer) throws Exception {
-        require(this.purchases.containsKey(buyer), Messages.RECORD_NOT_FOUND);
+        require(this.purchases.containsKey(buyer), ExceptionMessages.RECORD_NOT_FOUND);
         Integer buyerPurchaseAmount = this.purchases.get(buyer);
-        require(buyerPurchaseAmount != null, Messages.BROKEN_RECORD);
+        require(buyerPurchaseAmount != null, ExceptionMessages.BROKEN_RECORD);
 
         int totalMilestones = basicInfo.milestoneCount;
         // finished milestone belongs to creator
@@ -65,9 +65,9 @@ public class WCABuyerInfo {
     }
 
     public int fullRefund(Hash160 buyer) throws Exception {
-        require(this.purchases.containsKey(buyer), Messages.RECORD_NOT_FOUND);
+        require(this.purchases.containsKey(buyer), ExceptionMessages.RECORD_NOT_FOUND);
         Integer amount = this.purchases.get(buyer);
-        require(amount != null, Messages.BROKEN_RECORD);
+        require(amount != null, ExceptionMessages.BROKEN_RECORD);
         this.purchases.remove(buyer);
         // add to remain token
         this.remainTokenCount += amount;

--- a/src/main/java/info/skyblond/nekohit/neo/domain/WCAPojo.java
+++ b/src/main/java/info/skyblond/nekohit/neo/domain/WCAPojo.java
@@ -1,5 +1,6 @@
 package info.skyblond.nekohit.neo.domain;
 
+import info.skyblond.nekohit.neo.contract.WCAAuxiliary;
 import io.neow3j.devpack.List;
 import io.neow3j.devpack.contracts.StdLib;
 
@@ -39,22 +40,18 @@ public class WCAPojo {
         this.remainTokenCount = buyerInfo.remainTokenCount;
         this.buyerCount = buyerInfo.purchases.keys().length;
 
-        if (!basicInfo.paid) {
-            // not paid
+        // update status first
+        basicInfo.updateStatus(milestones);
+        if (basicInfo.status == 0) {
             this.status = "PENDING";
-        } else if (
-                basicInfo.nextMilestoneIndex == 0
-                        && !milestones.get(0).isExpired()
-                        && !basicInfo.finished
-        ) {
-            // paid but not started
+        } else if (basicInfo.status == 1) {
             this.status = "OPEN";
-        } else if (!basicInfo.finished) {
-            // paid, started, but not finished
+        } else if (basicInfo.status == 2) {
             this.status = "ACTIVE";
-        } else {
-            // finished
+        } else if (basicInfo.status == 3) {
             this.status = "FINISHED";
+        } else {
+            this.status = "UNKNOWN";
         }
     }
 }

--- a/src/main/java/info/skyblond/nekohit/neo/domain/WCAPojo.java
+++ b/src/main/java/info/skyblond/nekohit/neo/domain/WCAPojo.java
@@ -41,7 +41,7 @@ public class WCAPojo {
         this.buyerCount = buyerInfo.purchases.keys().length;
 
         // update status first
-        basicInfo.updateStatus(milestones);
+        WCAAuxiliary.updateStatus(basicInfo, milestones);
         if (basicInfo.status == 0) {
             this.status = "PENDING";
         } else if (basicInfo.status == 1) {

--- a/src/main/java/info/skyblond/nekohit/neo/helper/Utils.java
+++ b/src/main/java/info/skyblond/nekohit/neo/helper/Utils.java
@@ -3,8 +3,10 @@ package info.skyblond.nekohit.neo.helper;
 import io.neow3j.crypto.ECKeyPair;
 import io.neow3j.transaction.Transaction;
 import io.neow3j.wallet.Account;
+import io.neow3j.wallet.Wallet;
 
 import java.math.BigInteger;
+import java.util.Scanner;
 
 public class Utils {
     /**
@@ -35,5 +37,16 @@ public class Utils {
     public static double getGasFeeFromTx(Transaction tx) {
         long fraction = tx.getSystemFee() + tx.getNetworkFee();
         return fraction / Math.pow(10, 8);
+    }
+
+    public static Wallet readWalletWIF() {
+        Scanner scanner = new Scanner(System.in);
+        System.out.println("Paste account WIF:");
+        String walletWIF = scanner.nextLine();
+        // flush WIF out of screen
+        for (int i = 0; i < 2000; i++) {
+            System.out.println();
+        }
+        return Wallet.withAccounts(Account.fromWIF(walletWIF));
     }
 }

--- a/src/test/java/info/skyblond/nekohit/neo/contract/ContractInvokeHelper.java
+++ b/src/test/java/info/skyblond/nekohit/neo/contract/ContractInvokeHelper.java
@@ -164,4 +164,19 @@ public class ContractInvokeHelper {
                 wallet
         );
     }
+
+    public static void cancelWCA(
+            SmartContract contract, String identifier, Wallet wallet
+    ) throws Throwable {
+        ContractTestFramework.invokeFunction(
+                contract, "cancelWCA",
+                new ContractParameter[]{
+                        ContractParameter.string(identifier)
+                },
+                new Signer[]{
+                        AccountSigner.calledByEntry(wallet.getDefaultAccount())
+                },
+                wallet
+        );
+    }
 }

--- a/src/test/java/info/skyblond/nekohit/neo/contract/WCACancelTest.java
+++ b/src/test/java/info/skyblond/nekohit/neo/contract/WCACancelTest.java
@@ -3,12 +3,10 @@ package info.skyblond.nekohit.neo.contract;
 import info.skyblond.nekohit.neo.domain.Messages;
 import io.neow3j.transaction.exceptions.TransactionConfigurationException;
 import io.neow3j.wallet.Wallet;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * This class test the cancel method for WCA.
@@ -62,27 +60,172 @@ public class WCACancelTest extends ContractTestFramework {
     }
 
     @Test
-    void testCancelPending() {
-        Assertions.assertTrue(false);
+    void testCancelPending() throws Throwable {
+        var identifier = "test_cancel_pending" + System.currentTimeMillis();
+        // create WCA
+        ContractInvokeHelper.createWCA(
+                getWcaContract(), "description",
+                1_00, 1_00,
+                new String[]{"milestone1"},
+                new String[]{"milestone1"},
+                new Long[]{System.currentTimeMillis() + 60 * 1000},
+                0, 100, false,
+                identifier, this.creatorWallet
+        );
+
+        assertDoesNotThrow(
+                () -> ContractInvokeHelper.cancelWCA(
+                        getWcaContract(), identifier, this.creatorWallet
+                )
+        );
     }
 
     @Test
-    void testCancelOpen() {
-        Assertions.assertTrue(false);
+    void testCancelOpen() throws Throwable {
+        Wallet buyerWallet1 = getTestWallet();
+        Wallet buyerWallet2 = getTestWallet();
+        Wallet testWallet = getTestWallet();
+        var buyer1Purchase = 400_00;
+        var buyer2Purchase = 500_00;
+        var totalAmount = 1000_00;
+        var stakeRate = 10;
+        var identifier = "test_cancel_open_" + System.currentTimeMillis();
+        // create WCA
+        ContractInvokeHelper.createAndPayWCA(
+                getWcaContract(), "description",
+                stakeRate, totalAmount,
+                new String[]{"milestone1", "milestone2", "milestone3"},
+                new String[]{"milestone1", "milestone2", "milestone3"},
+                new Long[]{
+                        System.currentTimeMillis() + 60 * 1000,
+                        System.currentTimeMillis() + 61 * 1000,
+                        System.currentTimeMillis() + 62 * 1000
+                },
+                0, 1, false,
+                identifier, testWallet
+        );
+
+        // purchase
+        // NOTE: one purchase per WCA per block. Since only one write operation will be accepted
+        //       by committee, rest of them will be discarded and become invalid.
+        transferToken(
+                getCatToken(), buyerWallet1,
+                getWcaContractAddress(),
+                buyer1Purchase, identifier, true
+        );
+        transferToken(
+                getCatToken(), buyerWallet2,
+                getWcaContractAddress(),
+                buyer2Purchase, identifier, true
+        );
+
+        var creatorOldBalance = getCatToken().getBalanceOf(testWallet.getDefaultAccount()).longValue();
+        var buyer1OldBalance = getCatToken().getBalanceOf(buyerWallet1.getDefaultAccount()).longValue();
+        var buyer2OldBalance = getCatToken().getBalanceOf(buyerWallet2.getDefaultAccount()).longValue();
+
+        ContractInvokeHelper.cancelWCA(getWcaContract(), identifier, testWallet);
+
+        var creatorNewBalance = getCatToken().getBalanceOf(testWallet.getDefaultAccount()).longValue();
+        var buyer1NewBalance = getCatToken().getBalanceOf(buyerWallet1.getDefaultAccount()).longValue();
+        var buyer2NewBalance = getCatToken().getBalanceOf(buyerWallet2.getDefaultAccount()).longValue();
+
+        // buy this time:
+        var staked = totalAmount * stakeRate / 100;
+        assertEquals(buyer1OldBalance + buyer1Purchase, buyer1NewBalance);
+        assertEquals(buyer2OldBalance + buyer2Purchase, buyer2NewBalance);
+        assertEquals(creatorOldBalance + staked, creatorNewBalance);
     }
 
     @Test
-    void testCancelActive() {
-        Assertions.assertTrue(false);
+    void testCancelActive() throws Throwable {
+        var identifier = "test_cancel_active" + System.currentTimeMillis();
+        // create WCA
+        ContractInvokeHelper.createAndPayWCA(
+                getWcaContract(), "description",
+                1_00, 1_00,
+                new String[]{"milestone1", "milestone2"},
+                new String[]{"milestone1", "milestone2"},
+                new Long[]{
+                        System.currentTimeMillis() + 60 * 1000,
+                        System.currentTimeMillis() + 60 * 1000 + 1
+                },
+                0, 100, false,
+                identifier, this.creatorWallet
+        );
+
+        ContractInvokeHelper.finishMilestone(
+                getWcaContract(), identifier, 0, "something",
+                this.creatorWallet);
+
+        var throwable = assertThrows(
+                TransactionConfigurationException.class,
+                () -> ContractInvokeHelper.cancelWCA(
+                        getWcaContract(), identifier, this.creatorWallet
+                )
+        );
+        assertTrue(
+                throwable.getMessage().contains(Messages.INVALID_STATUS_ALLOW_PENDING_AND_OPEN),
+                "Unknown exception: " + throwable.getMessage()
+        );
     }
 
     @Test
-    void testCancelFinished() {
-        Assertions.assertTrue(false);
+    void testCancelFinished() throws Throwable {
+        var identifier = "test_cancel_finished" + System.currentTimeMillis();
+        // create WCA
+        ContractInvokeHelper.createAndPayWCA(
+                getWcaContract(), "description",
+                1_00, 1_00,
+                new String[]{"milestone1"},
+                new String[]{"milestone1"},
+                new Long[]{System.currentTimeMillis() + 60 * 1000},
+                0, 100, false,
+                identifier, this.creatorWallet
+        );
+
+        ContractInvokeHelper.finishWCA(getWcaContract(), identifier, this.creatorWallet);
+
+        var throwable = assertThrows(
+                TransactionConfigurationException.class,
+                () -> ContractInvokeHelper.cancelWCA(
+                        getWcaContract(), identifier, this.creatorWallet
+                )
+        );
+        assertTrue(
+                throwable.getMessage().contains(Messages.INVALID_STATUS_ALLOW_PENDING_AND_OPEN),
+                "Unknown exception: " + throwable.getMessage()
+        );
     }
 
     @Test
-    void testDoubleCancel() {
-        Assertions.assertTrue(false);
+    void testDoubleCancel() throws Throwable {
+        var identifier = "test_double_cancel" + System.currentTimeMillis();
+        // create WCA
+        ContractInvokeHelper.createWCA(
+                getWcaContract(), "description",
+                1_00, 1_00,
+                new String[]{"milestone1"},
+                new String[]{"milestone1"},
+                new Long[]{System.currentTimeMillis() + 60 * 1000},
+                0, 100, false,
+                identifier, this.creatorWallet
+        );
+
+        assertDoesNotThrow(
+                () -> ContractInvokeHelper.cancelWCA(
+                        getWcaContract(), identifier, this.creatorWallet
+                )
+        );
+
+        var throwable = assertThrows(
+                TransactionConfigurationException.class,
+                () -> ContractInvokeHelper.cancelWCA(
+                        getWcaContract(), identifier, this.creatorWallet
+                )
+        );
+        assertTrue(
+                throwable.getMessage().contains(Messages.RECORD_NOT_FOUND),
+                "Unknown exception: " + throwable.getMessage()
+        );
     }
 }

--- a/src/test/java/info/skyblond/nekohit/neo/contract/WCACancelTest.java
+++ b/src/test/java/info/skyblond/nekohit/neo/contract/WCACancelTest.java
@@ -1,6 +1,6 @@
 package info.skyblond.nekohit.neo.contract;
 
-import info.skyblond.nekohit.neo.domain.Messages;
+import info.skyblond.nekohit.neo.domain.ExceptionMessages;
 import io.neow3j.transaction.exceptions.TransactionConfigurationException;
 import io.neow3j.wallet.Wallet;
 import org.junit.jupiter.api.Test;
@@ -28,7 +28,7 @@ public class WCACancelTest extends ContractTestFramework {
                 )
         );
         assertTrue(
-                throwable.getMessage().contains(Messages.RECORD_NOT_FOUND),
+                throwable.getMessage().contains(ExceptionMessages.RECORD_NOT_FOUND),
                 "Unknown exception: " + throwable.getMessage()
         );
     }
@@ -54,7 +54,7 @@ public class WCACancelTest extends ContractTestFramework {
                 )
         );
         assertTrue(
-                throwable.getMessage().contains(Messages.INVALID_SIGNATURE),
+                throwable.getMessage().contains(ExceptionMessages.INVALID_SIGNATURE),
                 "Unknown exception: " + throwable.getMessage()
         );
     }
@@ -164,7 +164,7 @@ public class WCACancelTest extends ContractTestFramework {
                 )
         );
         assertTrue(
-                throwable.getMessage().contains(Messages.INVALID_STATUS_ALLOW_PENDING_AND_OPEN),
+                throwable.getMessage().contains(ExceptionMessages.INVALID_STATUS_ALLOW_PENDING_AND_OPEN),
                 "Unknown exception: " + throwable.getMessage()
         );
     }
@@ -192,7 +192,7 @@ public class WCACancelTest extends ContractTestFramework {
                 )
         );
         assertTrue(
-                throwable.getMessage().contains(Messages.INVALID_STATUS_ALLOW_PENDING_AND_OPEN),
+                throwable.getMessage().contains(ExceptionMessages.INVALID_STATUS_ALLOW_PENDING_AND_OPEN),
                 "Unknown exception: " + throwable.getMessage()
         );
     }
@@ -224,7 +224,7 @@ public class WCACancelTest extends ContractTestFramework {
                 )
         );
         assertTrue(
-                throwable.getMessage().contains(Messages.RECORD_NOT_FOUND),
+                throwable.getMessage().contains(ExceptionMessages.RECORD_NOT_FOUND),
                 "Unknown exception: " + throwable.getMessage()
         );
     }

--- a/src/test/java/info/skyblond/nekohit/neo/contract/WCACancelTest.java
+++ b/src/test/java/info/skyblond/nekohit/neo/contract/WCACancelTest.java
@@ -1,0 +1,88 @@
+package info.skyblond.nekohit.neo.contract;
+
+import info.skyblond.nekohit.neo.domain.Messages;
+import io.neow3j.transaction.exceptions.TransactionConfigurationException;
+import io.neow3j.wallet.Wallet;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * This class test the cancel method for WCA.
+ * Including general check(caller, invalid id, double cancel),
+ * ok to cancel(pending and open),
+ * shouldn't cancel(active and finished).
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class WCACancelTest extends ContractTestFramework {
+    private final Wallet creatorWallet = getTestWallet();
+    private final Wallet testWallet = getTestWallet();
+
+    @Test
+    void testCancelNotFound() {
+        var throwable = assertThrows(
+                TransactionConfigurationException.class,
+                () -> ContractInvokeHelper.cancelWCA(
+                        getWcaContract(), "some_invalid_id", this.creatorWallet
+                )
+        );
+        assertTrue(
+                throwable.getMessage().contains(Messages.RECORD_NOT_FOUND),
+                "Unknown exception: " + throwable.getMessage()
+        );
+    }
+
+    @Test
+    void testCancelNotOwner() throws Throwable {
+        var identifier = "test_cancel_wca_not_owner" + System.currentTimeMillis();
+        // create WCA
+        ContractInvokeHelper.createWCA(
+                getWcaContract(), "description",
+                1_00, 1_00,
+                new String[]{"milestone1"},
+                new String[]{"milestone1"},
+                new Long[]{System.currentTimeMillis() + 60 * 1000},
+                0, 100, false,
+                identifier, this.creatorWallet
+        );
+
+        var throwable = assertThrows(
+                TransactionConfigurationException.class,
+                () -> ContractInvokeHelper.cancelWCA(
+                        getWcaContract(), identifier, this.testWallet
+                )
+        );
+        assertTrue(
+                throwable.getMessage().contains(Messages.INVALID_SIGNATURE),
+                "Unknown exception: " + throwable.getMessage()
+        );
+    }
+
+    @Test
+    void testCancelPending() {
+        Assertions.assertTrue(false);
+    }
+
+    @Test
+    void testCancelOpen() {
+        Assertions.assertTrue(false);
+    }
+
+    @Test
+    void testCancelActive() {
+        Assertions.assertTrue(false);
+    }
+
+    @Test
+    void testCancelFinished() {
+        Assertions.assertTrue(false);
+    }
+
+    @Test
+    void testDoubleCancel() {
+        Assertions.assertTrue(false);
+    }
+}

--- a/src/test/java/info/skyblond/nekohit/neo/contract/WCACreateTest.java
+++ b/src/test/java/info/skyblond/nekohit/neo/contract/WCACreateTest.java
@@ -1,6 +1,6 @@
 package info.skyblond.nekohit.neo.contract;
 
-import info.skyblond.nekohit.neo.domain.Messages;
+import info.skyblond.nekohit.neo.domain.ExceptionMessages;
 import io.neow3j.transaction.AccountSigner;
 import io.neow3j.transaction.Signer;
 import io.neow3j.transaction.exceptions.TransactionConfigurationException;
@@ -39,7 +39,7 @@ public class WCACreateTest extends ContractTestFramework {
                 )
         );
         assertTrue(
-                throwable.getMessage().contains(Messages.INVALID_STAKE_RATE),
+                throwable.getMessage().contains(ExceptionMessages.INVALID_STAKE_RATE),
                 "Unknown exception: " + throwable.getMessage()
         );
     }
@@ -60,7 +60,7 @@ public class WCACreateTest extends ContractTestFramework {
                 )
         );
         assertTrue(
-                throwable.getMessage().contains(Messages.INVALID_STAKE_RATE),
+                throwable.getMessage().contains(ExceptionMessages.INVALID_STAKE_RATE),
                 "Unknown exception: " + throwable.getMessage()
         );
     }
@@ -81,7 +81,7 @@ public class WCACreateTest extends ContractTestFramework {
                 )
         );
         assertTrue(
-                throwable.getMessage().contains(Messages.INVALID_MAX_SELL_AMOUNT),
+                throwable.getMessage().contains(ExceptionMessages.INVALID_MAX_SELL_AMOUNT),
                 "Unknown exception: " + throwable.getMessage()
         );
     }
@@ -102,7 +102,7 @@ public class WCACreateTest extends ContractTestFramework {
                 )
         );
         assertTrue(
-                throwable.getMessage().contains(Messages.INVALID_MAX_SELL_AMOUNT),
+                throwable.getMessage().contains(ExceptionMessages.INVALID_MAX_SELL_AMOUNT),
                 "Unknown exception: " + throwable.getMessage()
         );
     }
@@ -135,7 +135,7 @@ public class WCACreateTest extends ContractTestFramework {
                 }
         );
         assertTrue(
-                throwable.getMessage().contains(Messages.INVALID_SIGNATURE),
+                throwable.getMessage().contains(ExceptionMessages.INVALID_SIGNATURE),
                 "Unknown exception: " + throwable.getMessage()
         );
     }
@@ -165,7 +165,7 @@ public class WCACreateTest extends ContractTestFramework {
                 )
         );
         assertTrue(
-                throwable.getMessage().contains(Messages.DUPLICATED_ID),
+                throwable.getMessage().contains(ExceptionMessages.DUPLICATED_ID),
                 "Unknown exception: " + throwable.getMessage()
         );
     }
@@ -186,7 +186,7 @@ public class WCACreateTest extends ContractTestFramework {
                 )
         );
         assertTrue(
-                throwable.getMessage().contains(Messages.INVALID_MILESTONES_COUNT),
+                throwable.getMessage().contains(ExceptionMessages.INVALID_MILESTONES_COUNT),
                 "Unknown exception: " + throwable.getMessage()
         );
     }
@@ -207,7 +207,7 @@ public class WCACreateTest extends ContractTestFramework {
                 )
         );
         assertTrue(
-                throwable.getMessage().contains(Messages.INVALID_TIMESTAMP),
+                throwable.getMessage().contains(ExceptionMessages.INVALID_TIMESTAMP),
                 "Unknown exception: " + throwable.getMessage()
         );
     }
@@ -229,7 +229,7 @@ public class WCACreateTest extends ContractTestFramework {
                 )
         );
         assertTrue(
-                throwable.getMessage().contains(Messages.EXPIRED_TIMESTAMP),
+                throwable.getMessage().contains(ExceptionMessages.EXPIRED_TIMESTAMP),
                 "Unknown exception: " + throwable.getMessage()
         );
     }
@@ -253,7 +253,7 @@ public class WCACreateTest extends ContractTestFramework {
                 )
         );
         assertTrue(
-                throwable.getMessage().contains(Messages.INVALID_THRESHOLD_INDEX),
+                throwable.getMessage().contains(ExceptionMessages.INVALID_THRESHOLD_INDEX),
                 "Unknown exception: " + throwable.getMessage()
         );
 
@@ -271,7 +271,7 @@ public class WCACreateTest extends ContractTestFramework {
                 )
         );
         assertTrue(
-                throwable.getMessage().contains(Messages.INVALID_THRESHOLD_INDEX),
+                throwable.getMessage().contains(ExceptionMessages.INVALID_THRESHOLD_INDEX),
                 "Unknown exception: " + throwable.getMessage()
         );
     }
@@ -292,7 +292,7 @@ public class WCACreateTest extends ContractTestFramework {
                 )
         );
         assertTrue(
-                throwable.getMessage().contains(Messages.INVALID_COOL_DOWN_INTERVAL),
+                throwable.getMessage().contains(ExceptionMessages.INVALID_COOL_DOWN_INTERVAL),
                 "Unknown exception: " + throwable.getMessage()
         );
     }

--- a/src/test/java/info/skyblond/nekohit/neo/contract/WCACreateTest.java
+++ b/src/test/java/info/skyblond/nekohit/neo/contract/WCACreateTest.java
@@ -1,5 +1,6 @@
 package info.skyblond.nekohit.neo.contract;
 
+import info.skyblond.nekohit.neo.domain.Messages;
 import io.neow3j.transaction.AccountSigner;
 import io.neow3j.transaction.Signer;
 import io.neow3j.transaction.exceptions.TransactionConfigurationException;
@@ -134,7 +135,7 @@ public class WCACreateTest extends ContractTestFramework {
                 }
         );
         assertTrue(
-                throwable.getMessage().contains("Invalid sender signature."),
+                throwable.getMessage().contains(Messages.INVALID_SIGNATURE),
                 "Unknown exception: " + throwable.getMessage()
         );
     }
@@ -164,7 +165,7 @@ public class WCACreateTest extends ContractTestFramework {
                 )
         );
         assertTrue(
-                throwable.getMessage().contains("Duplicate identifier."),
+                throwable.getMessage().contains(Messages.DUPLICATED_ID),
                 "Unknown exception: " + throwable.getMessage()
         );
     }
@@ -185,7 +186,7 @@ public class WCACreateTest extends ContractTestFramework {
                 )
         );
         assertTrue(
-                throwable.getMessage().contains("Cannot decide milestones count."),
+                throwable.getMessage().contains(Messages.INVALID_MILESTONES_COUNT),
                 "Unknown exception: " + throwable.getMessage()
         );
     }
@@ -206,7 +207,7 @@ public class WCACreateTest extends ContractTestFramework {
                 )
         );
         assertTrue(
-                throwable.getMessage().contains("The end timestamp should increase."),
+                throwable.getMessage().contains(Messages.INVALID_TIMESTAMP),
                 "Unknown exception: " + throwable.getMessage()
         );
     }
@@ -228,7 +229,7 @@ public class WCACreateTest extends ContractTestFramework {
                 )
         );
         assertTrue(
-                throwable.getMessage().contains("The end timestamp is already expired."),
+                throwable.getMessage().contains(Messages.EXPIRED_TIMESTAMP),
                 "Unknown exception: " + throwable.getMessage()
         );
     }

--- a/src/test/java/info/skyblond/nekohit/neo/contract/WCACreateTest.java
+++ b/src/test/java/info/skyblond/nekohit/neo/contract/WCACreateTest.java
@@ -39,7 +39,7 @@ public class WCACreateTest extends ContractTestFramework {
                 )
         );
         assertTrue(
-                throwable.getMessage().contains("The stake amount per 100 token must be positive."),
+                throwable.getMessage().contains(Messages.INVALID_STAKE_RATE),
                 "Unknown exception: " + throwable.getMessage()
         );
     }
@@ -60,7 +60,7 @@ public class WCACreateTest extends ContractTestFramework {
                 )
         );
         assertTrue(
-                throwable.getMessage().contains("The stake amount per 100 token must be positive."),
+                throwable.getMessage().contains(Messages.INVALID_STAKE_RATE),
                 "Unknown exception: " + throwable.getMessage()
         );
     }
@@ -81,7 +81,7 @@ public class WCACreateTest extends ContractTestFramework {
                 )
         );
         assertTrue(
-                throwable.getMessage().contains("The max sell token count must be positive."),
+                throwable.getMessage().contains(Messages.INVALID_MAX_SELL_AMOUNT),
                 "Unknown exception: " + throwable.getMessage()
         );
     }
@@ -102,7 +102,7 @@ public class WCACreateTest extends ContractTestFramework {
                 )
         );
         assertTrue(
-                throwable.getMessage().contains("The max sell token count must be positive."),
+                throwable.getMessage().contains(Messages.INVALID_MAX_SELL_AMOUNT),
                 "Unknown exception: " + throwable.getMessage()
         );
     }
@@ -253,7 +253,7 @@ public class WCACreateTest extends ContractTestFramework {
                 )
         );
         assertTrue(
-                throwable.getMessage().contains("Invalid value for thresholdIndex"),
+                throwable.getMessage().contains(Messages.INVALID_THRESHOLD_INDEX),
                 "Unknown exception: " + throwable.getMessage()
         );
 
@@ -271,7 +271,7 @@ public class WCACreateTest extends ContractTestFramework {
                 )
         );
         assertTrue(
-                throwable.getMessage().contains("Invalid value for thresholdIndex"),
+                throwable.getMessage().contains(Messages.INVALID_THRESHOLD_INDEX),
                 "Unknown exception: " + throwable.getMessage()
         );
     }
@@ -292,7 +292,7 @@ public class WCACreateTest extends ContractTestFramework {
                 )
         );
         assertTrue(
-                throwable.getMessage().contains("Cool down interval must not be negative."),
+                throwable.getMessage().contains(Messages.INVALID_COOL_DOWN_INTERVAL),
                 "Unknown exception: " + throwable.getMessage()
         );
     }

--- a/src/test/java/info/skyblond/nekohit/neo/contract/WCAFinishMilestoneTest.java
+++ b/src/test/java/info/skyblond/nekohit/neo/contract/WCAFinishMilestoneTest.java
@@ -1,6 +1,6 @@
 package info.skyblond.nekohit.neo.contract;
 
-import info.skyblond.nekohit.neo.domain.Messages;
+import info.skyblond.nekohit.neo.domain.ExceptionMessages;
 import io.neow3j.transaction.exceptions.TransactionConfigurationException;
 import io.neow3j.wallet.Wallet;
 import org.junit.jupiter.api.Test;
@@ -28,7 +28,7 @@ public class WCAFinishMilestoneTest extends ContractTestFramework {
                 )
         );
         assertTrue(
-                throwable.getMessage().contains(Messages.RECORD_NOT_FOUND),
+                throwable.getMessage().contains(ExceptionMessages.RECORD_NOT_FOUND),
                 "Unknown exception: " + throwable.getMessage()
         );
     }
@@ -54,7 +54,7 @@ public class WCAFinishMilestoneTest extends ContractTestFramework {
                 )
         );
         assertTrue(
-                throwable.getMessage().contains(Messages.INVALID_SIGNATURE),
+                throwable.getMessage().contains(ExceptionMessages.INVALID_SIGNATURE),
                 "Unknown exception: " + throwable.getMessage()
         );
     }
@@ -80,7 +80,7 @@ public class WCAFinishMilestoneTest extends ContractTestFramework {
                 )
         );
         assertTrue(
-                throwable.getMessage().contains(Messages.INVALID_STATUS_ALLOW_OPEN_AND_ACTIVE),
+                throwable.getMessage().contains(ExceptionMessages.INVALID_STATUS_ALLOW_OPEN_AND_ACTIVE),
                 "Unknown exception: " + throwable.getMessage()
         );
     }
@@ -111,7 +111,7 @@ public class WCAFinishMilestoneTest extends ContractTestFramework {
         );
 
         assertTrue(
-                throwable.getMessage().contains(Messages.COOL_DOWN_TIME_NOT_MET),
+                throwable.getMessage().contains(ExceptionMessages.COOL_DOWN_TIME_NOT_MET),
                 "Unknown exception: " + throwable.getMessage()
         );
     }
@@ -146,7 +146,7 @@ public class WCAFinishMilestoneTest extends ContractTestFramework {
         );
 
         assertTrue(
-                throwable.getMessage().contains(Messages.INVALID_MILESTONE_PASSED),
+                throwable.getMessage().contains(ExceptionMessages.INVALID_MILESTONE_PASSED),
                 "Unknown exception: " + throwable.getMessage()
         );
     }
@@ -180,7 +180,7 @@ public class WCAFinishMilestoneTest extends ContractTestFramework {
         );
 
         assertTrue(
-                throwable.getMessage().contains(Messages.INVALID_MILESTONE_PASSED),
+                throwable.getMessage().contains(ExceptionMessages.INVALID_MILESTONE_PASSED),
                 "Unknown exception: " + throwable.getMessage()
         );
     }
@@ -212,7 +212,7 @@ public class WCAFinishMilestoneTest extends ContractTestFramework {
         );
 
         assertTrue(
-                throwable.getMessage().contains(Messages.INVALID_MILESTONE_EXPIRED),
+                throwable.getMessage().contains(ExceptionMessages.INVALID_MILESTONE_EXPIRED),
                 "Unknown exception: " + throwable.getMessage()
         );
     }
@@ -242,7 +242,7 @@ public class WCAFinishMilestoneTest extends ContractTestFramework {
         );
 
         assertTrue(
-                throwable.getMessage().contains(Messages.INVALID_PROOF_OF_WORK),
+                throwable.getMessage().contains(ExceptionMessages.INVALID_PROOF_OF_WORK),
                 "Unknown exception: " + throwable.getMessage()
         );
     }

--- a/src/test/java/info/skyblond/nekohit/neo/contract/WCAFinishMilestoneTest.java
+++ b/src/test/java/info/skyblond/nekohit/neo/contract/WCAFinishMilestoneTest.java
@@ -1,5 +1,6 @@
 package info.skyblond.nekohit.neo.contract;
 
+import info.skyblond.nekohit.neo.domain.Messages;
 import io.neow3j.transaction.exceptions.TransactionConfigurationException;
 import io.neow3j.wallet.Wallet;
 import org.junit.jupiter.api.Test;
@@ -27,7 +28,7 @@ public class WCAFinishMilestoneTest extends ContractTestFramework {
                 )
         );
         assertTrue(
-                throwable.getMessage().contains("Identifier not found."),
+                throwable.getMessage().contains(Messages.ID_NOT_FOUND),
                 "Unknown exception: " + throwable.getMessage()
         );
     }
@@ -53,7 +54,7 @@ public class WCAFinishMilestoneTest extends ContractTestFramework {
                 )
         );
         assertTrue(
-                throwable.getMessage().contains("Invalid caller signature."),
+                throwable.getMessage().contains(Messages.INVALID_SIGNATURE),
                 "Unknown exception: " + throwable.getMessage()
         );
     }
@@ -79,7 +80,7 @@ public class WCAFinishMilestoneTest extends ContractTestFramework {
                 )
         );
         assertTrue(
-                throwable.getMessage().contains("You can't finish an unpaid WCA."),
+                throwable.getMessage().contains(Messages.INVALID_STATUS_ALLOW_OPEN_AND_ACTIVE),
                 "Unknown exception: " + throwable.getMessage()
         );
     }

--- a/src/test/java/info/skyblond/nekohit/neo/contract/WCAFinishMilestoneTest.java
+++ b/src/test/java/info/skyblond/nekohit/neo/contract/WCAFinishMilestoneTest.java
@@ -28,7 +28,7 @@ public class WCAFinishMilestoneTest extends ContractTestFramework {
                 )
         );
         assertTrue(
-                throwable.getMessage().contains(Messages.ID_NOT_FOUND),
+                throwable.getMessage().contains(Messages.RECORD_NOT_FOUND),
                 "Unknown exception: " + throwable.getMessage()
         );
     }
@@ -111,7 +111,7 @@ public class WCAFinishMilestoneTest extends ContractTestFramework {
         );
 
         assertTrue(
-                throwable.getMessage().contains("Cool down time not met"),
+                throwable.getMessage().contains(Messages.COOL_DOWN_TIME_NOT_MET),
                 "Unknown exception: " + throwable.getMessage()
         );
     }
@@ -146,7 +146,7 @@ public class WCAFinishMilestoneTest extends ContractTestFramework {
         );
 
         assertTrue(
-                throwable.getMessage().contains("You can't finish a passed milestone"),
+                throwable.getMessage().contains(Messages.INVALID_MILESTONE_PASSED),
                 "Unknown exception: " + throwable.getMessage()
         );
     }
@@ -180,7 +180,7 @@ public class WCAFinishMilestoneTest extends ContractTestFramework {
         );
 
         assertTrue(
-                throwable.getMessage().contains("You can't finish a passed milestone"),
+                throwable.getMessage().contains(Messages.INVALID_MILESTONE_PASSED),
                 "Unknown exception: " + throwable.getMessage()
         );
     }
@@ -212,7 +212,7 @@ public class WCAFinishMilestoneTest extends ContractTestFramework {
         );
 
         assertTrue(
-                throwable.getMessage().contains("You can't finish a expired milestone"),
+                throwable.getMessage().contains(Messages.INVALID_MILESTONE_EXPIRED),
                 "Unknown exception: " + throwable.getMessage()
         );
     }
@@ -242,7 +242,7 @@ public class WCAFinishMilestoneTest extends ContractTestFramework {
         );
 
         assertTrue(
-                throwable.getMessage().contains("Proof of work must be valid."),
+                throwable.getMessage().contains(Messages.INVALID_PROOF_OF_WORK),
                 "Unknown exception: " + throwable.getMessage()
         );
     }

--- a/src/test/java/info/skyblond/nekohit/neo/contract/WCAFinishWCATest.java
+++ b/src/test/java/info/skyblond/nekohit/neo/contract/WCAFinishWCATest.java
@@ -1,5 +1,6 @@
 package info.skyblond.nekohit.neo.contract;
 
+import info.skyblond.nekohit.neo.domain.Messages;
 import io.neow3j.transaction.exceptions.TransactionConfigurationException;
 import io.neow3j.wallet.Wallet;
 import org.junit.jupiter.api.Test;
@@ -28,7 +29,7 @@ public class WCAFinishWCATest extends ContractTestFramework {
                 )
         );
         assertTrue(
-                throwable.getMessage().contains("Identifier not found."),
+                throwable.getMessage().contains(Messages.ID_NOT_FOUND),
                 "Unknown exception: " + throwable.getMessage()
         );
     }
@@ -54,7 +55,7 @@ public class WCAFinishWCATest extends ContractTestFramework {
                 )
         );
         assertTrue(
-                throwable.getMessage().contains("You can not finish an unpaid WCA."),
+                throwable.getMessage().contains(Messages.INVALID_STATUS_ALLOW_OPEN_AND_ACTIVE),
                 "Unknown exception: " + throwable.getMessage()
         );
     }
@@ -80,7 +81,7 @@ public class WCAFinishWCATest extends ContractTestFramework {
                 )
         );
         assertTrue(
-                throwable.getMessage().contains("You can only apply this to a ready-to-finish WCA."),
+                throwable.getMessage().contains(Messages.INVALID_STATUS_ALLOW_READY_TO_FINISH),
                 "Unknown exception: " + throwable.getMessage()
         );
     }
@@ -131,7 +132,7 @@ public class WCAFinishWCATest extends ContractTestFramework {
                 )
         );
         assertTrue(
-                throwable.getMessage().contains("You can not finish a WCA twice."),
+                throwable.getMessage().contains(Messages.INVALID_STATUS_ALLOW_OPEN_AND_ACTIVE),
                 "Unknown exception: " + throwable.getMessage()
         );
     }
@@ -161,7 +162,7 @@ public class WCAFinishWCATest extends ContractTestFramework {
                 )
         );
         assertTrue(
-                throwable.getMessage().contains("You can not finish a WCA twice."),
+                throwable.getMessage().contains(Messages.INVALID_STATUS_ALLOW_OPEN_AND_ACTIVE),
                 "Unknown exception: " + throwable.getMessage()
         );
     }

--- a/src/test/java/info/skyblond/nekohit/neo/contract/WCAFinishWCATest.java
+++ b/src/test/java/info/skyblond/nekohit/neo/contract/WCAFinishWCATest.java
@@ -1,6 +1,6 @@
 package info.skyblond.nekohit.neo.contract;
 
-import info.skyblond.nekohit.neo.domain.Messages;
+import info.skyblond.nekohit.neo.domain.ExceptionMessages;
 import io.neow3j.transaction.exceptions.TransactionConfigurationException;
 import io.neow3j.wallet.Wallet;
 import org.junit.jupiter.api.Test;
@@ -29,7 +29,7 @@ public class WCAFinishWCATest extends ContractTestFramework {
                 )
         );
         assertTrue(
-                throwable.getMessage().contains(Messages.RECORD_NOT_FOUND),
+                throwable.getMessage().contains(ExceptionMessages.RECORD_NOT_FOUND),
                 "Unknown exception: " + throwable.getMessage()
         );
     }
@@ -55,7 +55,7 @@ public class WCAFinishWCATest extends ContractTestFramework {
                 )
         );
         assertTrue(
-                throwable.getMessage().contains(Messages.INVALID_STATUS_ALLOW_OPEN_AND_ACTIVE),
+                throwable.getMessage().contains(ExceptionMessages.INVALID_STATUS_ALLOW_OPEN_AND_ACTIVE),
                 "Unknown exception: " + throwable.getMessage()
         );
     }
@@ -81,7 +81,7 @@ public class WCAFinishWCATest extends ContractTestFramework {
                 )
         );
         assertTrue(
-                throwable.getMessage().contains(Messages.INVALID_STATUS_ALLOW_READY_TO_FINISH),
+                throwable.getMessage().contains(ExceptionMessages.INVALID_STATUS_ALLOW_READY_TO_FINISH),
                 "Unknown exception: " + throwable.getMessage()
         );
     }
@@ -132,7 +132,7 @@ public class WCAFinishWCATest extends ContractTestFramework {
                 )
         );
         assertTrue(
-                throwable.getMessage().contains(Messages.INVALID_STATUS_ALLOW_OPEN_AND_ACTIVE),
+                throwable.getMessage().contains(ExceptionMessages.INVALID_STATUS_ALLOW_OPEN_AND_ACTIVE),
                 "Unknown exception: " + throwable.getMessage()
         );
     }
@@ -162,7 +162,7 @@ public class WCAFinishWCATest extends ContractTestFramework {
                 )
         );
         assertTrue(
-                throwable.getMessage().contains(Messages.INVALID_STATUS_ALLOW_OPEN_AND_ACTIVE),
+                throwable.getMessage().contains(ExceptionMessages.INVALID_STATUS_ALLOW_OPEN_AND_ACTIVE),
                 "Unknown exception: " + throwable.getMessage()
         );
     }

--- a/src/test/java/info/skyblond/nekohit/neo/contract/WCAFinishWCATest.java
+++ b/src/test/java/info/skyblond/nekohit/neo/contract/WCAFinishWCATest.java
@@ -29,7 +29,7 @@ public class WCAFinishWCATest extends ContractTestFramework {
                 )
         );
         assertTrue(
-                throwable.getMessage().contains(Messages.ID_NOT_FOUND),
+                throwable.getMessage().contains(Messages.RECORD_NOT_FOUND),
                 "Unknown exception: " + throwable.getMessage()
         );
     }

--- a/src/test/java/info/skyblond/nekohit/neo/contract/WCAPurchaseTest.java
+++ b/src/test/java/info/skyblond/nekohit/neo/contract/WCAPurchaseTest.java
@@ -62,7 +62,7 @@ public class WCAPurchaseTest extends ContractTestFramework {
                 )
         );
         assertTrue(
-                throwable.getMessage().contains(Messages.ID_NOT_FOUND),
+                throwable.getMessage().contains(Messages.RECORD_NOT_FOUND),
                 "Unknown exception: " + throwable.getMessage()
         );
     }

--- a/src/test/java/info/skyblond/nekohit/neo/contract/WCAPurchaseTest.java
+++ b/src/test/java/info/skyblond/nekohit/neo/contract/WCAPurchaseTest.java
@@ -1,6 +1,6 @@
 package info.skyblond.nekohit.neo.contract;
 
-import info.skyblond.nekohit.neo.domain.Messages;
+import info.skyblond.nekohit.neo.domain.ExceptionMessages;
 import io.neow3j.transaction.AccountSigner;
 import io.neow3j.transaction.Signer;
 import io.neow3j.transaction.exceptions.TransactionConfigurationException;
@@ -43,7 +43,7 @@ public class WCAPurchaseTest extends ContractTestFramework {
                 )
         );
         assertTrue(
-                throwable.getMessage().contains(Messages.INVALID_CALLER),
+                throwable.getMessage().contains(ExceptionMessages.INVALID_CALLER),
                 "Unknown exception: " + throwable.getMessage()
         );
     }
@@ -62,7 +62,7 @@ public class WCAPurchaseTest extends ContractTestFramework {
                 )
         );
         assertTrue(
-                throwable.getMessage().contains(Messages.RECORD_NOT_FOUND),
+                throwable.getMessage().contains(ExceptionMessages.RECORD_NOT_FOUND),
                 "Unknown exception: " + throwable.getMessage()
         );
     }
@@ -91,7 +91,7 @@ public class WCAPurchaseTest extends ContractTestFramework {
                 )
         );
         assertTrue(
-                throwable.getMessage().contains(Messages.INVALID_STATUS_ALLOW_PENDING),
+                throwable.getMessage().contains(ExceptionMessages.INVALID_STATUS_ALLOW_PENDING),
                 "Unknown exception: " + throwable.getMessage()
         );
     }
@@ -173,7 +173,7 @@ public class WCAPurchaseTest extends ContractTestFramework {
                 )
         );
         assertTrue(
-                throwable.getMessage().contains(Messages.INVALID_STATUS_ALLOW_OPEN_AND_ACTIVE),
+                throwable.getMessage().contains(ExceptionMessages.INVALID_STATUS_ALLOW_OPEN_AND_ACTIVE),
                 "Unknown exception: " + throwable.getMessage()
         );
     }
@@ -207,7 +207,7 @@ public class WCAPurchaseTest extends ContractTestFramework {
                 )
         );
         assertTrue(
-                throwable.getMessage().contains(Messages.INVALID_STATUS_READY_TO_FINISH),
+                throwable.getMessage().contains(ExceptionMessages.INVALID_STATUS_READY_TO_FINISH),
                 "Unknown exception: " + throwable.getMessage()
         );
     }

--- a/src/test/java/info/skyblond/nekohit/neo/contract/WCARefundTest.java
+++ b/src/test/java/info/skyblond/nekohit/neo/contract/WCARefundTest.java
@@ -34,7 +34,7 @@ public class WCARefundTest extends ContractTestFramework {
                 )
         );
         assertTrue(
-                throwable.getMessage().contains(Messages.ID_NOT_FOUND),
+                throwable.getMessage().contains(Messages.RECORD_NOT_FOUND),
                 "Unknown exception: " + throwable.getMessage()
         );
     }
@@ -170,7 +170,7 @@ public class WCARefundTest extends ContractTestFramework {
         );
 
         assertTrue(
-                throwable.getMessage().contains("Purchase not found"),
+                throwable.getMessage().contains(Messages.RECORD_NOT_FOUND),
                 "Unknown exception: " + throwable.getMessage()
         );
     }
@@ -203,7 +203,7 @@ public class WCARefundTest extends ContractTestFramework {
         );
 
         assertTrue(
-                throwable.getMessage().contains("Purchase not found"),
+                throwable.getMessage().contains(Messages.RECORD_NOT_FOUND),
                 "Unknown exception: " + throwable.getMessage()
         );
     }

--- a/src/test/java/info/skyblond/nekohit/neo/contract/WCARefundTest.java
+++ b/src/test/java/info/skyblond/nekohit/neo/contract/WCARefundTest.java
@@ -1,5 +1,6 @@
 package info.skyblond.nekohit.neo.contract;
 
+import info.skyblond.nekohit.neo.domain.Messages;
 import io.neow3j.transaction.AccountSigner;
 import io.neow3j.transaction.Signer;
 import io.neow3j.transaction.exceptions.TransactionConfigurationException;
@@ -33,7 +34,7 @@ public class WCARefundTest extends ContractTestFramework {
                 )
         );
         assertTrue(
-                throwable.getMessage().contains("Identifier not found."),
+                throwable.getMessage().contains(Messages.ID_NOT_FOUND),
                 "Unknown exception: " + throwable.getMessage()
         );
     }
@@ -55,7 +56,7 @@ public class WCARefundTest extends ContractTestFramework {
                 )
         );
         assertTrue(
-                throwable.getMessage().contains("Invalid sender signature."),
+                throwable.getMessage().contains(Messages.INVALID_SIGNATURE),
                 "Unknown exception: " + throwable.getMessage()
         );
     }
@@ -82,7 +83,7 @@ public class WCARefundTest extends ContractTestFramework {
                 )
         );
         assertTrue(
-                throwable.getMessage().contains("You can not refund an unpaid WCA."),
+                throwable.getMessage().contains(Messages.INVALID_STATUS_ALLOW_OPEN_AND_ACTIVE),
                 "Unknown exception: " + throwable.getMessage()
         );
     }
@@ -112,7 +113,7 @@ public class WCARefundTest extends ContractTestFramework {
                 )
         );
         assertTrue(
-                throwable.getMessage().contains("You can not refund a finished WCA."),
+                throwable.getMessage().contains(Messages.INVALID_STATUS_ALLOW_OPEN_AND_ACTIVE),
                 "Unknown exception: " + throwable.getMessage()
         );
     }
@@ -140,7 +141,7 @@ public class WCARefundTest extends ContractTestFramework {
                 )
         );
         assertTrue(
-                throwable.getMessage().contains("You can not refund a finished WCA."),
+                throwable.getMessage().contains(Messages.INVALID_STATUS_READY_TO_FINISH),
                 "Unknown exception: " + throwable.getMessage()
         );
     }

--- a/src/test/java/info/skyblond/nekohit/neo/contract/WCARefundTest.java
+++ b/src/test/java/info/skyblond/nekohit/neo/contract/WCARefundTest.java
@@ -1,6 +1,6 @@
 package info.skyblond.nekohit.neo.contract;
 
-import info.skyblond.nekohit.neo.domain.Messages;
+import info.skyblond.nekohit.neo.domain.ExceptionMessages;
 import io.neow3j.transaction.AccountSigner;
 import io.neow3j.transaction.Signer;
 import io.neow3j.transaction.exceptions.TransactionConfigurationException;
@@ -34,7 +34,7 @@ public class WCARefundTest extends ContractTestFramework {
                 )
         );
         assertTrue(
-                throwable.getMessage().contains(Messages.RECORD_NOT_FOUND),
+                throwable.getMessage().contains(ExceptionMessages.RECORD_NOT_FOUND),
                 "Unknown exception: " + throwable.getMessage()
         );
     }
@@ -56,7 +56,7 @@ public class WCARefundTest extends ContractTestFramework {
                 )
         );
         assertTrue(
-                throwable.getMessage().contains(Messages.INVALID_SIGNATURE),
+                throwable.getMessage().contains(ExceptionMessages.INVALID_SIGNATURE),
                 "Unknown exception: " + throwable.getMessage()
         );
     }
@@ -83,7 +83,7 @@ public class WCARefundTest extends ContractTestFramework {
                 )
         );
         assertTrue(
-                throwable.getMessage().contains(Messages.INVALID_STATUS_ALLOW_OPEN_AND_ACTIVE),
+                throwable.getMessage().contains(ExceptionMessages.INVALID_STATUS_ALLOW_OPEN_AND_ACTIVE),
                 "Unknown exception: " + throwable.getMessage()
         );
     }
@@ -113,7 +113,7 @@ public class WCARefundTest extends ContractTestFramework {
                 )
         );
         assertTrue(
-                throwable.getMessage().contains(Messages.INVALID_STATUS_ALLOW_OPEN_AND_ACTIVE),
+                throwable.getMessage().contains(ExceptionMessages.INVALID_STATUS_ALLOW_OPEN_AND_ACTIVE),
                 "Unknown exception: " + throwable.getMessage()
         );
     }
@@ -141,7 +141,7 @@ public class WCARefundTest extends ContractTestFramework {
                 )
         );
         assertTrue(
-                throwable.getMessage().contains(Messages.INVALID_STATUS_READY_TO_FINISH),
+                throwable.getMessage().contains(ExceptionMessages.INVALID_STATUS_READY_TO_FINISH),
                 "Unknown exception: " + throwable.getMessage()
         );
     }
@@ -170,7 +170,7 @@ public class WCARefundTest extends ContractTestFramework {
         );
 
         assertTrue(
-                throwable.getMessage().contains(Messages.RECORD_NOT_FOUND),
+                throwable.getMessage().contains(ExceptionMessages.RECORD_NOT_FOUND),
                 "Unknown exception: " + throwable.getMessage()
         );
     }
@@ -203,7 +203,7 @@ public class WCARefundTest extends ContractTestFramework {
         );
 
         assertTrue(
-                throwable.getMessage().contains(Messages.RECORD_NOT_FOUND),
+                throwable.getMessage().contains(ExceptionMessages.RECORD_NOT_FOUND),
                 "Unknown exception: " + throwable.getMessage()
         );
     }


### PR DESCRIPTION
Refactor:
+ Introduce WCA status, instead of && or || a lof of conditions or fields.
  + Status: `PENDING` (created), `OPEN` (paid stake), `ACTIVE` (pass the threshold milestone), `FINISHED` (tokens are transferred)
  + Note: `Ready-To-Finish` is not a physical status but a sub status of `ACTIVE`. A WCA is `Ready-To-Finish` if and only if the last milestone is expired or finished (in this case, finish the last milestone should trigger the `finishWCA` and make WCA become `FINISHED`)
+ Allow purchase at anytime (OPEN, ACTIVE, but not ReadyToFinish)
+ Add some helper functions
+ Replace all exception messages with static Strings

CancelWCA:
+ Now you can cancel/delete/remove a WCA when it's PENDING or OPEN.
+ Cancel a PENDING WCA just delete the data
+ Cancel an OPEN WCA will return all the tokens and delete the data

CodeQL:
+ This is recommended by GitHub Action, to scan security flaws in the code. I'm not sure it's useful for contract codes.
