### PR TITLE
Move to neow3j's test framework

### DIFF
--- a/.github/workflows/feature.yml
+++ b/.github/workflows/feature.yml
@@ -13,17 +13,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      # Install neo express from dotnet tool
-      - name: Install neoxp
-        run: |
-          wget https://packages.microsoft.com/config/ubuntu/21.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb
-          sudo dpkg -i packages-microsoft-prod.deb
-          sudo apt-get update
-          sudo apt-get install -y apt-transport-https
-          sudo apt-get install -y dotnet-sdk-5.0
-          sudo apt-get install libsnappy-dev libc6-dev librocksdb-dev -y
-          dotnet tool install --global Neo.Express --version 3.0.21
-      
       # Set up JDK 11
       - name: Set up JDK 11
         uses: actions/setup-java@v2
@@ -31,10 +20,6 @@ jobs:
           java-version: '11'
           distribution: 'adopt'
 
-      # Start up neoxp in background
-      - name: Start up neoxp
-        run: neoxp run -s 1 >> neo.log &
-        
       # Test using gradle
       - name: Unit test
         run: ./gradlew test

--- a/src/test/java/com/nekohit/neo/contract/CatTokenTest.java
+++ b/src/test/java/com/nekohit/neo/contract/CatTokenTest.java
@@ -14,7 +14,6 @@ import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
-import static com.nekohit.neo.contract.TestConstants.CONTRACT_OWNER_ACCOUNT;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**

--- a/src/test/java/com/nekohit/neo/contract/CatTokenTest.java
+++ b/src/test/java/com/nekohit/neo/contract/CatTokenTest.java
@@ -2,15 +2,15 @@ package com.nekohit.neo.contract;
 
 import io.neow3j.contract.FungibleToken;
 import io.neow3j.contract.exceptions.UnexpectedReturnTypeException;
+import io.neow3j.test.ContractTest;
 import io.neow3j.transaction.AccountSigner;
 import io.neow3j.transaction.Signer;
 import io.neow3j.transaction.exceptions.TransactionConfigurationException;
 import io.neow3j.types.ContractParameter;
 import io.neow3j.types.Hash160;
 import io.neow3j.wallet.Account;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
-import org.junit.jupiter.api.TestInstance.Lifecycle;
 
 import java.io.IOException;
 
@@ -20,9 +20,16 @@ import static org.junit.jupiter.api.Assertions.*;
 /**
  * Test the CatToken.
  */
-@TestInstance(Lifecycle.PER_CLASS)
+@ContractTest(blockTime = 1, contracts = {
+        CatToken.class,
+})
 public class CatTokenTest extends ContractTestFramework {
-    private final Account testAccount = getTestAccount();
+    private Account testAccount;
+
+    @BeforeEach
+    void setUp() {
+        testAccount = getTestAccount();
+    }
 
     @Test
     void testSymbol() throws UnexpectedReturnTypeException, IOException {
@@ -210,7 +217,7 @@ public class CatTokenTest extends ContractTestFramework {
         var throwable = assertThrows(
                 TransactionConfigurationException.class,
                 () -> transferToken(
-                        GAS_TOKEN, this.testAccount, getCatTokenAddress(),
+                        gasToken, this.testAccount, getCatTokenAddress(),
                         1, null, false
                 )
         );
@@ -225,19 +232,19 @@ public class CatTokenTest extends ContractTestFramework {
         var exchangeAmount = 1_000000L;
         // Query old balance
         var oldCatBalance = getCatToken().getBalanceOf(this.testAccount).longValue();
-        var oldTotalSupply = new FungibleToken(getCatTokenAddress(), NEOW3J).getTotalSupply().longValue();
+        var oldTotalSupply = new FungibleToken(getCatTokenAddress(), neow3j).getTotalSupply().longValue();
 
         // do the transfer
         assertDoesNotThrow(
                 () -> transferToken(
-                        GAS_TOKEN, this.testAccount, getCatTokenAddress(),
+                        gasToken, this.testAccount, getCatTokenAddress(),
                         exchangeAmount, null, true
                 )
         );
 
         // query new balance
         var newCatBalance = getCatToken().getBalanceOf(this.testAccount).longValue();
-        var newTotalSupply = new FungibleToken(getCatTokenAddress(), NEOW3J).getTotalSupply().longValue();
+        var newTotalSupply = new FungibleToken(getCatTokenAddress(), neow3j).getTotalSupply().longValue();
 
         // check change
         assertEquals(2_00, newCatBalance - oldCatBalance);
@@ -249,8 +256,8 @@ public class CatTokenTest extends ContractTestFramework {
         var destroyAmount = 2_00;
         // Query old balance
         var oldCatBalance = getCatToken().getBalanceOf(this.testAccount).longValue();
-        var oldGasBalance = GAS_TOKEN.getBalanceOf(this.testAccount).longValue();
-        var oldTotalSupply = new FungibleToken(getCatTokenAddress(), NEOW3J).getTotalSupply().longValue();
+        var oldGasBalance = gasToken.getBalanceOf(this.testAccount).longValue();
+        var oldTotalSupply = new FungibleToken(getCatTokenAddress(), neow3j).getTotalSupply().longValue();
 
         // do the transfer
         assertDoesNotThrow(
@@ -266,8 +273,8 @@ public class CatTokenTest extends ContractTestFramework {
 
         // query new balance
         var newCatBalance = getCatToken().getBalanceOf(this.testAccount).longValue();
-        var newGasBalance = GAS_TOKEN.getBalanceOf(this.testAccount).longValue();
-        var newTotalSupply = new FungibleToken(getCatTokenAddress(), NEOW3J).getTotalSupply().longValue();
+        var newGasBalance = gasToken.getBalanceOf(this.testAccount).longValue();
+        var newTotalSupply = new FungibleToken(getCatTokenAddress(), neow3j).getTotalSupply().longValue();
 
         // check change
         assertEquals(2_00, oldCatBalance - newCatBalance);

--- a/src/test/java/com/nekohit/neo/contract/ContractTestFramework.java
+++ b/src/test/java/com/nekohit/neo/contract/ContractTestFramework.java
@@ -28,7 +28,6 @@ import java.math.BigInteger;
 import java.util.Arrays;
 import java.util.Objects;
 
-import static com.nekohit.neo.contract.TestConstants.CONTRACT_OWNER_ACCOUNT;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
@@ -42,6 +41,7 @@ public class ContractTestFramework {
     @RegisterExtension
     private static final ContractTestExtension ext = new ContractTestExtension();
 
+    protected static final Account CONTRACT_OWNER_ACCOUNT = TestUtils.createAccountFromPrivateKey("4d742d3c83124e4fe037488ff1428f57d092e436b120cd45b4f808c45f6b4700");
     protected static FungibleToken catToken = null;
     protected static SmartContract wcaContract = null;
     protected static Neow3j neow3j = null;

--- a/src/test/java/com/nekohit/neo/contract/GASFeeTest.java
+++ b/src/test/java/com/nekohit/neo/contract/GASFeeTest.java
@@ -1,9 +1,9 @@
 package com.nekohit.neo.contract;
 
+import io.neow3j.test.ContractTest;
 import io.neow3j.wallet.Account;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
-import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -11,12 +11,22 @@ import org.slf4j.LoggerFactory;
  * This test measure the gas usage for each WCA operation.
  * No function is tested.
  */
-@TestInstance(Lifecycle.PER_CLASS)
+@ContractTest(blockTime = 1, contracts = {
+        CatToken.class,
+        WCAContract.class,
+})
 public class GASFeeTest extends ContractTestFramework {
     private final Logger logger = LoggerFactory.getLogger(GASFeeTest.class);
-    private final Account creatorAccount = getTestAccount();
-    private final Account buyer1Account = getTestAccount();
-    private final Account buyer2Account = getTestAccount();
+    private Account creatorAccount;
+    private Account buyer1Account;
+    private Account buyer2Account;
+
+    @BeforeEach
+    void setUp() {
+        creatorAccount = getTestAccount();
+        buyer1Account = getTestAccount();
+        buyer2Account = getTestAccount();
+    }
 
     @Test
     void test() throws Throwable {

--- a/src/test/java/com/nekohit/neo/contract/TestConstants.java
+++ b/src/test/java/com/nekohit/neo/contract/TestConstants.java
@@ -1,9 +1,0 @@
-package com.nekohit.neo.contract;
-
-import com.nekohit.neo.TestUtils;
-import io.neow3j.wallet.Account;
-
-public class TestConstants {
-    public static final Account CONTRACT_OWNER_ACCOUNT = TestUtils.createAccountFromPrivateKey("4d742d3c83124e4fe037488ff1428f57d092e436b120cd45b4f808c45f6b4700");
-
-}

--- a/src/test/java/com/nekohit/neo/contract/TestConstants.java
+++ b/src/test/java/com/nekohit/neo/contract/TestConstants.java
@@ -3,12 +3,7 @@ package com.nekohit.neo.contract;
 import com.nekohit.neo.TestUtils;
 import io.neow3j.wallet.Account;
 
-import java.util.List;
-
 public class TestConstants {
-    public static final Account NODE_ACCOUNT = TestUtils.createAccountFromPrivateKey("57363779306c5100ca960cc39055f93fb114640c63616f2c570af809dc4b5c8e");
-    public static final Account GENESIS_ACCOUNT = Account.createMultiSigAccount(
-            List.of(NODE_ACCOUNT.getECKeyPair().getPublicKey()), 1);
     public static final Account CONTRACT_OWNER_ACCOUNT = TestUtils.createAccountFromPrivateKey("4d742d3c83124e4fe037488ff1428f57d092e436b120cd45b4f808c45f6b4700");
 
 }

--- a/src/test/java/com/nekohit/neo/contract/WCACancelTest.java
+++ b/src/test/java/com/nekohit/neo/contract/WCACancelTest.java
@@ -1,10 +1,11 @@
 package com.nekohit.neo.contract;
 
 import com.nekohit.neo.domain.ExceptionMessages;
+import io.neow3j.test.ContractTest;
 import io.neow3j.transaction.exceptions.TransactionConfigurationException;
 import io.neow3j.wallet.Account;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -14,10 +15,19 @@ import static org.junit.jupiter.api.Assertions.*;
  * ok to cancel(pending and open),
  * shouldn't cancel(active and finished).
  */
-@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@ContractTest(blockTime = 1, contracts = {
+        CatToken.class,
+        WCAContract.class,
+})
 public class WCACancelTest extends ContractTestFramework {
-    private final Account creatorAccount = getTestAccount();
-    private final Account testAccount = getTestAccount();
+    private Account creatorAccount;
+    private Account testAccount;
+
+    @BeforeEach
+    void setUp() {
+        creatorAccount = getTestAccount();
+        testAccount = getTestAccount();
+    }
 
     @Test
     void testCancelNotFound() {

--- a/src/test/java/com/nekohit/neo/contract/WCACreateTest.java
+++ b/src/test/java/com/nekohit/neo/contract/WCACreateTest.java
@@ -1,14 +1,14 @@
 package com.nekohit.neo.contract;
 
 import com.nekohit.neo.domain.ExceptionMessages;
+import io.neow3j.test.ContractTest;
 import io.neow3j.transaction.AccountSigner;
 import io.neow3j.transaction.Signer;
 import io.neow3j.transaction.exceptions.TransactionConfigurationException;
 import io.neow3j.types.ContractParameter;
 import io.neow3j.wallet.Account;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
-import org.junit.jupiter.api.TestInstance.Lifecycle;
 
 import java.util.List;
 
@@ -18,9 +18,17 @@ import static org.junit.jupiter.api.Assertions.*;
  * This class test the creation of WCA.
  * Including invalid parameter, invalid milestones, duplicate identifier, etc.
  */
-@TestInstance(Lifecycle.PER_CLASS)
+@ContractTest(blockTime = 1, contracts = {
+        CatToken.class,
+        WCAContract.class,
+})
 public class WCACreateTest extends ContractTestFramework {
-    private final Account testAccount = getTestAccount();
+    private Account testAccount;
+
+    @BeforeEach
+    void setUp() {
+        testAccount = getTestAccount();
+    }
 
     @Test
     void testNegativeStakeRate() {

--- a/src/test/java/com/nekohit/neo/contract/WCAFinishMilestoneTest.java
+++ b/src/test/java/com/nekohit/neo/contract/WCAFinishMilestoneTest.java
@@ -1,11 +1,11 @@
 package com.nekohit.neo.contract;
 
 import com.nekohit.neo.domain.ExceptionMessages;
+import io.neow3j.test.ContractTest;
 import io.neow3j.transaction.exceptions.TransactionConfigurationException;
 import io.neow3j.wallet.Account;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
-import org.junit.jupiter.api.TestInstance.Lifecycle;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -15,9 +15,17 @@ import static org.junit.jupiter.api.Assertions.*;
  * cool down time not met, missed ms, finished ms, expired ms,
  * proof of work is null, normal op
  */
-@TestInstance(Lifecycle.PER_CLASS)
+@ContractTest(blockTime = 1, contracts = {
+        CatToken.class,
+        WCAContract.class,
+})
 public class WCAFinishMilestoneTest extends ContractTestFramework {
-    private final Account testAccount = getTestAccount();
+    private Account testAccount;
+
+    @BeforeEach
+    void setUp() {
+        testAccount = getTestAccount();
+    }
 
     @Test
     void testInvalidId() {

--- a/src/test/java/com/nekohit/neo/contract/WCAFinishWCATest.java
+++ b/src/test/java/com/nekohit/neo/contract/WCAFinishWCATest.java
@@ -1,11 +1,11 @@
 package com.nekohit.neo.contract;
 
 import com.nekohit.neo.domain.ExceptionMessages;
+import io.neow3j.test.ContractTest;
 import io.neow3j.transaction.exceptions.TransactionConfigurationException;
 import io.neow3j.wallet.Account;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
-import org.junit.jupiter.api.TestInstance.Lifecycle;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -14,11 +14,21 @@ import static org.junit.jupiter.api.Assertions.*;
  * Including invalid id, unpaid, not ready to finish(last ms not finished nor expired),
  * owner override, double finished, normal op(check token distribution)
  */
-@TestInstance(Lifecycle.PER_CLASS)
+@ContractTest(blockTime = 1, contracts = {
+        CatToken.class,
+        WCAContract.class,
+})
 public class WCAFinishWCATest extends ContractTestFramework {
-    private final Account creatorAccount = getTestAccount();
-    private final Account buyerAccount1 = getTestAccount();
-    private final Account buyerAccount2 = getTestAccount();
+    private Account creatorAccount;
+    private Account buyerAccount1;
+    private Account buyerAccount2;
+
+    @BeforeEach
+    void setUp() {
+        creatorAccount = getTestAccount();
+        buyerAccount1 = getTestAccount();
+        buyerAccount2 = getTestAccount();
+    }
 
     @Test
     void testInvalidId() {

--- a/src/test/java/com/nekohit/neo/contract/WCAPurchaseTest.java
+++ b/src/test/java/com/nekohit/neo/contract/WCAPurchaseTest.java
@@ -1,11 +1,11 @@
 package com.nekohit.neo.contract;
 
 import com.nekohit.neo.domain.ExceptionMessages;
+import io.neow3j.test.ContractTest;
 import io.neow3j.transaction.exceptions.TransactionConfigurationException;
 import io.neow3j.wallet.Account;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
-import org.junit.jupiter.api.TestInstance.Lifecycle;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -16,10 +16,19 @@ import static org.junit.jupiter.api.Assertions.*;
  * purchase(unpaid, already start, first ms not finished but expired, insufficient remain,
  * normal op(one shot, multiple purchase)).
  */
-@TestInstance(Lifecycle.PER_CLASS)
+@ContractTest(blockTime = 1, contracts = {
+        CatToken.class,
+        WCAContract.class,
+})
 public class WCAPurchaseTest extends ContractTestFramework {
-    private final Account creatorAccount = getTestAccount();
-    private final Account testAccount = getTestAccount();
+    private Account creatorAccount;
+    private Account testAccount;
+
+    @BeforeEach
+    void setUp() {
+        creatorAccount = getTestAccount();
+        testAccount = getTestAccount();
+    }
 
     @Test
     void testInvalidId() {
@@ -116,7 +125,7 @@ public class WCAPurchaseTest extends ContractTestFramework {
         var throwable = assertThrows(
                 TransactionConfigurationException.class,
                 () -> transferToken(
-                        GAS_TOKEN, this.creatorAccount,
+                        gasToken, this.creatorAccount,
                         getWcaContractAddress(),
                         1_00, identifier, false
                 )
@@ -198,7 +207,7 @@ public class WCAPurchaseTest extends ContractTestFramework {
         var throwable = assertThrows(
                 TransactionConfigurationException.class,
                 () -> transferToken(
-                        GAS_TOKEN, this.testAccount,
+                        gasToken, this.testAccount,
                         getWcaContractAddress(),
                         10, identifier, false
                 )

--- a/src/test/java/com/nekohit/neo/contract/WCAQueryTest.java
+++ b/src/test/java/com/nekohit/neo/contract/WCAQueryTest.java
@@ -1,5 +1,6 @@
 package com.nekohit.neo.contract;
 
+import io.neow3j.test.ContractTest;
 import io.neow3j.transaction.AccountSigner;
 import io.neow3j.transaction.Signer;
 import io.neow3j.types.ContractParameter;
@@ -7,9 +8,8 @@ import io.neow3j.types.Hash160;
 import io.neow3j.wallet.Account;
 import org.apache.commons.codec.binary.Hex;
 import org.bouncycastle.util.Arrays;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
-import org.junit.jupiter.api.TestInstance.Lifecycle;
 
 import static com.nekohit.neo.contract.TestConstants.CONTRACT_OWNER_ACCOUNT;
 import static org.junit.jupiter.api.Assertions.*;
@@ -18,10 +18,19 @@ import static org.junit.jupiter.api.Assertions.*;
  * This class test query methods for WCA.
  * Including valid response and invalid or expection handle.
  */
-@TestInstance(Lifecycle.PER_CLASS)
+@ContractTest(blockTime = 1, contracts = {
+        CatToken.class,
+        WCAContract.class,
+})
 public class WCAQueryTest extends ContractTestFramework {
-    private final Account creatorAccount = getTestAccount();
-    private final Account testAccount = getTestAccount();
+    private Account creatorAccount;
+    private Account testAccount;
+
+    @BeforeEach
+    void setUp() {
+        creatorAccount = getTestAccount();
+        testAccount = getTestAccount();
+    }
 
     @Test
     void testInvalidQueryWCA() {
@@ -141,7 +150,7 @@ public class WCAQueryTest extends ContractTestFramework {
     @Test
     void testAdvancedQuery() throws Throwable {
         var buyerAccount = getTestAccount();
-        var unpaidWCA = ContractInvokeHelper.declareProject(
+        ContractInvokeHelper.declareProject(
                 getWcaContract(), "description",
                 getCatTokenAddress(), 1_00, 1_00,
                 new String[]{"milestone1", "milestone2", "milestone3"},

--- a/src/test/java/com/nekohit/neo/contract/WCAQueryTest.java
+++ b/src/test/java/com/nekohit/neo/contract/WCAQueryTest.java
@@ -11,7 +11,6 @@ import org.bouncycastle.util.Arrays;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import static com.nekohit.neo.contract.TestConstants.CONTRACT_OWNER_ACCOUNT;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**

--- a/src/test/java/com/nekohit/neo/contract/WCARefundTest.java
+++ b/src/test/java/com/nekohit/neo/contract/WCARefundTest.java
@@ -1,14 +1,14 @@
 package com.nekohit.neo.contract;
 
 import com.nekohit.neo.domain.ExceptionMessages;
+import io.neow3j.test.ContractTest;
 import io.neow3j.transaction.AccountSigner;
 import io.neow3j.transaction.Signer;
 import io.neow3j.transaction.exceptions.TransactionConfigurationException;
 import io.neow3j.types.ContractParameter;
 import io.neow3j.wallet.Account;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
-import org.junit.jupiter.api.TestInstance.Lifecycle;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -17,10 +17,19 @@ import static org.junit.jupiter.api.Assertions.*;
  * Including invalid id, invalid signer, unpaid, last ms is finished, last ms expired.
  * record not found, normal op(before and after threshold)
  */
-@TestInstance(Lifecycle.PER_CLASS)
+@ContractTest(blockTime = 1, contracts = {
+        CatToken.class,
+        WCAContract.class,
+})
 public class WCARefundTest extends ContractTestFramework {
-    private final Account creatorAccount = getTestAccount();
-    private final Account testAccount = getTestAccount();
+    private Account creatorAccount;
+    private Account testAccount;
+
+    @BeforeEach
+    void setUp() {
+        creatorAccount = getTestAccount();
+        testAccount = getTestAccount();
+    }
 
     @Test
     void testInvalidId() {


### PR DESCRIPTION
Moving to neow3j's test framework.

Now the test action uses 6+ min rather than 4+ min, however, the test env is more consistent. Now the test is running in the docker, instead of bare metal, and won't depend on what version of neo express is installed on the host.